### PR TITLE
IOS: Fixed #131: Changed NSURLSession configuration to ephemeral one.

### DIFF
--- a/proj-xcode/Classes/networking/client/PA2Client.m
+++ b/proj-xcode/Classes/networking/client/PA2Client.m
@@ -78,7 +78,7 @@
 		PA2Log(@"Warning: Using HTTP for communication may create a serious security issue! Use HTTPS in production.");
 	}
 	
-	NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+	NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
 	configuration.URLCache = nil;
 	
 	NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
@@ -244,7 +244,7 @@
 #pragma mark - NSURLSessionDelegate methods
 
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
-	if (self.sslValidationStrategy) {
+	if (self.sslValidationStrategy && [challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
 		[self.sslValidationStrategy validateSslForSession:session challenge:challenge completionHandler:completionHandler];
 	} else {
 		completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);

--- a/proj-xcode/Classes/networking/ssl/PA2ClientSslNoValidationStrategy.m
+++ b/proj-xcode/Classes/networking/ssl/PA2ClientSslNoValidationStrategy.m
@@ -26,11 +26,8 @@
 	// Allow any SSL certificate
 	
 	PA2CriticalWarning(@"SSL validation is disabled. This code must not be present in production!");
-	if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]){
-		NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
-		completionHandler(NSURLSessionAuthChallengeUseCredential,credential);
-	}
-	
+	NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+	completionHandler(NSURLSessionAuthChallengeUseCredential,credential);
 }
 
 @end

--- a/proj-xcode/Classes/networking/ssl/PA2ClientSslValidationStrategy.h
+++ b/proj-xcode/Classes/networking/ssl/PA2ClientSslValidationStrategy.h
@@ -18,6 +18,12 @@
 
 @protocol PA2ClientSslValidationStrategy <NSObject>
 
+/**
+ The method is called when an underlying NSURLSession first establishes a connection to a remote server that uses SSL or TLS,
+ to allow your app to verify the server’s certificate chain. The challenge parameter is already tested for `NSURLAuthenticationMethodServerTrust`.
+ 
+ The implementation must call `completionHandler` with an appropriate result of the verification.
+ */
 - (void) validateSslForSession:(NSURLSession *)session
 					 challenge:(NSURLAuthenticationChallenge *)challenge
 			 completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler;


### PR DESCRIPTION
validateSslForSession is now called only for server trust challenges.

Close #131 