### PR TITLE
Crypto3: OtpUtil now supports V3 activation codes with CRC-16 checksum.

### DIFF
--- a/include/PowerAuth/OtpUtil.h
+++ b/include/PowerAuth/OtpUtil.h
@@ -29,17 +29,13 @@ namespace powerAuth
 	 code. You can use methods from `OtpUtil` class to fill this structure with valid data.
 	 */
 	struct OtpComponents
-	{
+	{		
 		/**
-		 Short activation ID
+		 Activation code.
 		 */
-		std::string activationIdShort;
+		std::string activationCode;
 		/**
-		 Activation OTP (one time password)
-		 */
-		std::string activationOtp;
-		/**
-		 Signature calculated from activationIdShort and activationOtp.
+		 Signature calculated from activationCode.
 		 The value is typically optional for cases, when the user re-typed activation ode
 		 manually.
 		 */

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/util/otp/Otp.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/util/otp/Otp.java
@@ -24,11 +24,18 @@ public class Otp {
     /**
      * Short activation ID
      */
+    @Deprecated
     public final String activationIdShort;
     /**
      * Activation OTP (one time password)
      */
+    @Deprecated
     public final String activationOtp;
+
+    /**
+     * Activation code, without signature part.
+     */
+    public final String activationCode;
     /**
      * Signature calculated from activationIdShort and activationOtp.
      * The value is typically optional for cases, when the user re-typed activation code
@@ -42,19 +49,25 @@ public class Otp {
     public Otp() {
         this.activationIdShort = null;
         this.activationOtp = null;
+        this.activationCode = null;
         this.activationSignature = null;
     }
 
     //
     // Getters for compatibility with older codes
     //
-
+    @Deprecated
     public String getActivationIdShort() {
         return activationIdShort;
     }
 
+    @Deprecated
     public String getActivationOtp() {
         return activationOtp;
+    }
+
+    public String getActivationCode() {
+        return activationCode;
     }
 
     public String getActivationSignature() {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/util/otp/OtpUtil.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/util/otp/OtpUtil.java
@@ -17,7 +17,17 @@
 package io.getlime.security.powerauth.util.otp;
 
 /**
- * Class for parsing and validation the OTP code.
+ * Class for parsing and validation the activation code.
+ *
+ * Current format of code:
+ * <pre>
+ * code without signature:  CCCCC-CCCCC-CCCCC-CCCCC
+ * code with signature:     CCCCC-CCCCC-CCCCC-CCCCC#BASE64_STRING_WITH_SIGNATURE
+ * </pre>
+ *
+ * Where the 'C' is Base32 sequence of characters, fully decodable into the sequence of bytes.
+ * The validator then compares CRC-16 checksum calculated for the first 10 bytes and compares
+ * it to last two bytes (in big endian order).
  */
 public class OtpUtil {
 
@@ -27,7 +37,7 @@ public class OtpUtil {
 
     /**
      * Parses an input |activationCode| (which may or may not contain an optional signature) and
-     * returns Otp object filled with valid data. The method doesn't perform an autocorrection,
+     * returns Otp object filled with valid data. The method doesn't perform an auto-correction,
      * so the provided code must be valid.
      *
      * @return Otp object if code is valid, or null
@@ -43,9 +53,9 @@ public class OtpUtil {
     /**
      * Validates an input |utfCodepoint| and returns 0 if it's not valid or cannot be corrected.
      * The non-zero returned value contains the same input character, or the corrected
-     * one. You can use this method for validation &amp; autocorrection of just typed characters.
+     * one. You can use this method for validation &amp; auto-correction of just typed characters.
      * <p>
-     * The function performs following autocorrections:
+     * The function performs following auto-corrections:
      * <ul>
      * <li>lowercase characters are corrected to uppercase (e.g. 'a' will be corrected to 'A')</li>
      * <li>'0' is corrected to 'O' (zero to capital O)</li>

--- a/proj-xcode/Classes/core/PA2OtpUtil.h
+++ b/proj-xcode/Classes/core/PA2OtpUtil.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import "PA2Macros.h"
 
 /**
  The `PA2Otp` object contains parsed components from user-provided activation
@@ -24,11 +24,16 @@
 /**
  Short activation ID
  */
-@property (nonnull, nonatomic, strong, readonly) NSString* activationIdShort;
+@property (nonnull, nonatomic, strong, readonly) NSString* activationIdShort PA2_DEPRECATED("to-remove");
 /**
  Activation OTP (one time password)
  */
-@property (nonnull, nonatomic, strong, readonly) NSString* activationOtp;
+@property (nonnull, nonatomic, strong, readonly) NSString* activationOtp PA2_DEPRECATED("to-remove");
+
+/**
+ Activation code, without signature part.
+ */
+@property (nonnull, nonatomic, strong, readonly) NSString * activationCode;
 /**
  Signature calculated from activationIdShort and activationOtp.
  The value is typically optional for cases, when the user re-typed activation ode
@@ -47,7 +52,9 @@
  code without signature:	CCCCC-CCCCC-CCCCC-CCCCC
  code with signature:		CCCCC-CCCCC-CCCCC-CCCCC#BASE64_STRING_WITH_SIGNATURE
  
- Where the 'C' is a character from range [A-Z2-7]
+ Where the 'C' is Base32 sequence of characters, fully decodable into the sequence of bytes.
+ The validator then compares CRC-16 checksum calculated for the first 10 bytes and compares
+ it to last two bytes (in big endian order).
  */
 @interface PA2OtpUtil : NSObject
 
@@ -62,9 +69,9 @@
 /**
  Validates an input |utfCodepoint| and returns '\0' (NUL) if it's not valid or cannot be corrected.
  The non-NUL returned value contains the same input character, or the corrected one.
- You can use this method for validation & autocorrection of just typed characters.
+ You can use this method for validation & auto-correction of just typed characters.
  
- The function performs following autocorections:
+ The function performs following auto-corections:
  - lowercase characters are corrected to uppercase (e.g. 'a' will be corrected to 'A')
  - '0' is corrected to 'O'
  - '1' is corrected to 'I'
@@ -81,7 +88,7 @@
 
 /**
  Parses an input |activationCode| (which may or may not contain an optional signature) and returns PA2Otp 
- object filled with valid data. The method doesn't perform an autocorrection, so the provided code must be valid.
+ object filled with valid data. The method doesn't perform an auto-correction, so the provided code must be valid.
  
  Returns PA2Otp object if code is valid, or nil.
  */

--- a/proj-xcode/Classes/core/PA2OtpUtil.mm
+++ b/proj-xcode/Classes/core/PA2OtpUtil.mm
@@ -37,12 +37,17 @@ using namespace io::getlime::powerAuth;
 
 - (NSString*) activationIdShort
 {
-	return cc7::objc::CopyToNullableNSString(_components.activationIdShort);
+	return nil;
 }
 
 - (NSString*) activationOtp
 {
-	return cc7::objc::CopyToNullableNSString(_components.activationOtp);
+	return nil;
+}
+
+- (NSString*) activationCode
+{
+	return cc7::objc::CopyToNSString(_components.activationCode);
 }
 
 - (NSString*) activationSignature

--- a/src/PowerAuth/jni/OtpUtilJNI.cpp
+++ b/src/PowerAuth/jni/OtpUtilJNI.cpp
@@ -48,8 +48,7 @@ CC7_JNI_METHOD_PARAMS(jobject, parseFromActivationCode, jstring activationCode)
 	// Copy cppResult into java result object
 	jclass  resultClazz  = CC7_JNI_MODULE_FIND_CLASS("Otp");
 	jobject resultObject = cc7::jni::CreateJavaObject(env, CC7_JNI_MODULE_CLASS_PATH("Otp"), "()V");
-	CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "activationIdShort",	cc7::jni::CopyToJavaString(env, cppComponents.activationIdShort));
-	CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "activationOtp",		cc7::jni::CopyToJavaString(env, cppComponents.activationOtp));
+	CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "activationCode",	cc7::jni::CopyToJavaString(env, cppComponents.activationCode));
 	CC7_JNI_SET_FIELD_STRING(resultObject, resultClazz, "activationSignature",	cc7::jni::CopyToNullableJavaString(env, cppComponents.activationSignature));
 	return resultObject;
 }


### PR DESCRIPTION
That deprecated interfaces will be removed later, when the whole activation implementation will be updated.