### PR TITLE
Crypto3: Core: Added activation versioning to status blob

### DIFF
--- a/include/PowerAuth/PublicTypes.h
+++ b/include/PowerAuth/PublicTypes.h
@@ -501,6 +501,16 @@ namespace powerAuth
 		};
 		
 		/**
+		 The Version enumeration defines version of activation data, stored on the server.
+		 */
+		enum Version
+		{
+			V2 = 2,				// PowerAuth Crypto V2
+			V3 = 3,				// PowerAuth Crypto V3
+			MaxSupported = V3,	// Max supported version defined by this SDK
+		};
+		
+		/**
 		 State of the activation
 		 */
 		State state;
@@ -513,10 +523,13 @@ namespace powerAuth
 		 */
 		cc7::U32 maxFailCount;
 		/**
-		 Counter on the server's side. The session should not synchronize
-		 itself with this counter.
+		 Current activation version stored on the server
 		 */
-		cc7::U64 counter;
+		cc7::byte currentVersion;
+		/**
+		 If different than `currentVersion`, then activation migration is available.
+		 */
+		cc7::byte upgradeVersion;
 		
 		/**
 		 Constructs a new empty activation status structure.
@@ -525,9 +538,15 @@ namespace powerAuth
 			state(Created),
 			failCount(0),
 			maxFailCount(0),
-			counter(0)
+			currentVersion(0),
+			upgradeVersion(0)
 		{
 		}
+		
+		/**
+		 Returns true if migration to a new activation data is possible.
+		 */
+		bool isMigrationAvailable() const;
 	};
 	
 	

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStatus.java
@@ -68,20 +68,45 @@ public class ActivationStatus {
         }
         return 0;
     }
-    
+
+    // Activation version
+
     /**
-     Signing counter on the server's side. This value is usable only
-     for the debugging purposes. You should avoid dumping this value
-     to the debug console.
+     Server contains activation V2 data.
      */
-    public final long counter;
-    
+    public static final int Version_V2 = 2;
+    /**
+     Server contains activation V3 data.
+     */
+    public static final int Version_V3 = 3;
+
+    /**
+     The activation version currently stored on the server.
+     You can compare this value to {@link #Version_V2} or {@link #Version_V3} constants.
+     */
+    public final int currentVersion;
+    /**
+     Defines version of data supported on the server. If the value is different than {@link #currentVersion},
+     then the activation migration is available.
+     You can compare this value to {@link #Version_V2} or {@link #Version_V3} constants.
+     */
+    public final int upgradeVersion;
+
+    /**
+     Contains true, if migration to newer activation data is available.
+     */
+    public final boolean isMigrationAvailable;
+
+
+    // Constructor
 
     public ActivationStatus() {
         this.errorCode = 0;
         this.state = 0;
         this.failCount = 0;
         this.maxFailCount = 0;
-        this.counter = 0;
+        this.currentVersion = 0;
+        this.upgradeVersion = 0;
+        this.isMigrationAvailable = false;
     }
 }

--- a/proj-xcode/Classes/core/PA2PrivateImpl.h
+++ b/proj-xcode/Classes/core/PA2PrivateImpl.h
@@ -53,6 +53,14 @@
 - (io::getlime::powerAuth::ECIESEncryptor &) encryptorRef;
 @end
 
+
+@interface PA2ActivationStatus (Private)
+@property (nonatomic, assign, readonly) UInt8 currentActivationVersion;
+@property (nonatomic, assign, readonly) UInt8 upgradeActivationVersion;
+@property (nonatomic, assign, readonly) BOOL isMigrationAvailable;
+@end
+
+
 /**
  Converts PA2SessionSetup object into SessionSetup C++ structure.
  */

--- a/proj-xcode/Classes/core/PA2Types.h
+++ b/proj-xcode/Classes/core/PA2Types.h
@@ -476,16 +476,6 @@ typedef NS_ENUM(int, PA2ActivationState) {
  */
 @property (nonatomic, assign, readonly) UInt32 remainingAttempts;
 
-/**
- Counter on the server's side. The value is only informational and may
- be used for debugging purposes. You can compare it with the value stored
- in the module's persistent data and deduce whether the server's counter
- is ahead or not.
- 
- You should NOT dumpt this value into the debug console.
- */
-@property (nonatomic, assign, readonly) UInt64 counter;
-
 @end
 
 #pragma mark - End to End Encryption -

--- a/proj-xcode/Classes/core/PA2Types.mm
+++ b/proj-xcode/Classes/core/PA2Types.mm
@@ -195,11 +195,6 @@ const PA2SignatureFactor PA2SignatureFactor_PrepareForVaultUnlock			= 0x1000;
 	return static_cast<PA2ActivationState>(_status.state);
 }
 
-- (UInt64) counter
-{
-	return _status.counter;
-}
-
 - (UInt32) failCount
 {
 	return _status.failCount;
@@ -234,9 +229,27 @@ const PA2SignatureFactor PA2SignatureFactor_PrepareForVaultUnlock			= 0x1000;
 			status_str = @"<<unknown>>"; break;
 			
 	}
-	return [NSString stringWithFormat:@"<PA2ActivationStatus %@, fails %@/%@, ctr %@>", status_str, @(_status.failCount), @(_status.maxFailCount), @(_status.counter)];
+	bool migration = _status.isMigrationAvailable();
+	return [NSString stringWithFormat:@"<PA2ActivationStatus %@, fails %@/%@%@>", status_str, @(_status.failCount), @(_status.maxFailCount), migration ? @", migration" : @""];
 }
 #endif
+
+// Private
+
+- (UInt8) currentActivationVersion
+{
+	return _status.currentVersion;
+}
+
+- (UInt8) upgradeActivationVersion
+{
+	return _status.upgradeVersion;
+}
+
+- (BOOL) isMigrationAvailable
+{
+	return _status.isMigrationAvailable();
+}
 
 @end
 

--- a/src/PowerAuth/PublicTypes.cpp
+++ b/src/PowerAuth/PublicTypes.cpp
@@ -101,6 +101,20 @@ namespace powerAuth
 		
 		return out;
 	}
+
+	
+	//
+	// MARK: - ActivationStatus -
+	//
+	
+	bool ActivationStatus::isMigrationAvailable() const
+	{
+		if (currentVersion < upgradeVersion) {
+			return upgradeVersion <= MaxSupported;
+		}
+		return false;
+	}
+	
 	
 } // io::getlime::powerAuth
 } // io::getlime

--- a/src/PowerAuth/jni/SessionJNI.cpp
+++ b/src/PowerAuth/jni/SessionJNI.cpp
@@ -349,10 +349,12 @@ CC7_JNI_METHOD_PARAMS(jobject, decodeActivationStatus, jstring statusBlob, jobje
 	jobject resultObject = cc7::jni::CreateJavaObject(env, CC7_JNI_MODULE_CLASS_PATH("ActivationStatus"), "()V");
 	CC7_JNI_SET_FIELD_INT(resultObject, resultClazz, "errorCode", code);
 	if (code == EC_Ok) {
-		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "state", 	 	cppStatus.state);
-		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "failCount", 	cppStatus.failCount);
-		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "maxFailCount",	cppStatus.maxFailCount);
-		CC7_JNI_SET_FIELD_LONG	(resultObject, resultClazz, "counter",	 	cppStatus.counter);
+		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "state", 	 			cppStatus.state);
+		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "failCount", 			cppStatus.failCount);
+		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "maxFailCount",			cppStatus.maxFailCount);
+		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "currentVersion",		cppStatus.currentVersion);
+		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "upgradeVersion",		cppStatus.upgradeVersion);
+		CC7_JNI_SET_FIELD_BOOL	(resultObject, resultClazz, "isMigrationAvailable",	cppStatus.isMigrationAvailable());
 	}
 	return resultObject;
 }


### PR DESCRIPTION
This PR is adding support for new fields to `ActivationStatus` / `PA2ActivationStatus` objects.