### PR TITLE
Fix #164: Fix NPE in PA2Client when PowerAuthClientConfiguration not set

### DIFF
--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -45,11 +45,20 @@ android {
         compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
         compile "com.android.support:support-fragment:${rootProject.ext.supportLibVersion}"
         compile 'com.google.code.gson:gson:2.8.5'
+
+        testImplementation 'junit:junit:4.12'
+        testImplementation 'org.robolectric:robolectric:4.0.2'
     }
 
     externalNativeBuild {
         ndkBuild {
             path 'jni/Android.mk'
+        }
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
 }

--- a/proj-android/PowerAuthLibrary/gradle.properties
+++ b/proj-android/PowerAuthLibrary/gradle.properties
@@ -1,3 +1,5 @@
 VERSION_NAME=0.19.2
 GROUP_ID=io.getlime.security.powerauth
 ARTIFACT_ID=powerauth-android-sdk
+
+android.enableUnitTestBinaryResources=true

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -148,7 +148,7 @@ public class PowerAuthSDK {
             } else {
                 instance.mClientConfiguration = new PowerAuthClientConfiguration.Builder().build();
             }
-            instance.mClient = new PA2Client(mConfiguration, mClientConfiguration);
+            instance.mClient = new PA2Client(instance.mConfiguration, instance.mClientConfiguration);
 
             instance.mStatusKeychain = new PA2Keychain(instance.mKeychainConfiguration.getKeychainStatusId());
             instance.mBiometryKeychain = new PA2Keychain(instance.mKeychainConfiguration.getKeychainBiometryId());
@@ -160,11 +160,11 @@ public class PowerAuthSDK {
             }
 
             final SessionSetup sessionSetup = new SessionSetup(
-                    mConfiguration.getAppKey(),
-                    mConfiguration.getAppSecret(),
-                    mConfiguration.getMasterServerPublicKey(),
+                    instance.mConfiguration.getAppKey(),
+                    instance.mConfiguration.getAppSecret(),
+                    instance.mConfiguration.getMasterServerPublicKey(),
                     0,
-                    mConfiguration.getExternalEncryptionKey()
+                    instance.mConfiguration.getExternalEncryptionKey()
             );
 
             instance.mSession = new Session(sessionSetup);

--- a/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/sdk/PowerAuthSDKBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/sdk/PowerAuthSDKBuilderTest.java
@@ -1,0 +1,98 @@
+package io.getlime.security.powerauth.sdk;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Field;
+
+import io.getlime.security.powerauth.networking.client.PA2Client;
+import io.getlime.security.powerauth.shadow.ShadowDefaultSavePowerAuthStateListener;
+import io.getlime.security.powerauth.shadow.ShadowSession;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test that PowerAuthSDK.Builder configuration
+ * is properly propagated into the instances.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {
+        ShadowSession.class,
+        ShadowDefaultSavePowerAuthStateListener.class
+})
+public class PowerAuthSDKBuilderTest {
+
+    private PowerAuthConfiguration powerAuthConfiguration;
+
+    @Before
+    public void setUp() {
+        PowerAuthConfiguration.Builder builder = new PowerAuthConfiguration.Builder(
+                "com.wultra.android.powerauth.test",
+                "http://wultra.com",
+                "aaa",
+                "bbb",
+                "ccc");
+        powerAuthConfiguration = builder.build();
+    }
+
+    @Test
+    public void testClientConfigurationNull() throws Exception {
+        PowerAuthSDK.Builder builder = new PowerAuthSDK.Builder(powerAuthConfiguration);
+        PowerAuthSDK powerAuthSDK = builder
+                .build(RuntimeEnvironment.systemContext);
+
+        assertNotNull(powerAuthSDK);
+        assertNotNull(powerAuthSDK.getConfiguration());
+
+        Field clientConfigurationField = powerAuthSDK.getClass().getDeclaredField("mClientConfiguration");
+        clientConfigurationField.setAccessible(true);
+        PowerAuthClientConfiguration powerAuthClientConfiguration = (PowerAuthClientConfiguration) clientConfigurationField.get(powerAuthSDK);
+        assertNotNull(powerAuthClientConfiguration);
+
+        Field pa2ClientField = powerAuthSDK.getClass().getDeclaredField("mClient");
+        pa2ClientField.setAccessible(true);
+        PA2Client pa2Client = (PA2Client) pa2ClientField.get(powerAuthSDK);
+        assertNotNull(pa2Client);
+
+        PowerAuthClientConfiguration powerAuthClientConfigurationInClient = pa2Client.getClientConfiguration();
+        assertNotNull(powerAuthClientConfigurationInClient);
+
+        assertEquals(powerAuthClientConfiguration, powerAuthClientConfigurationInClient);
+    }
+
+    @Test
+    public void testClientConfigurationNonNull() throws Exception {
+        PowerAuthClientConfiguration srcClientConfiguration = new PowerAuthClientConfiguration.Builder()
+                .build();
+        PowerAuthSDK.Builder builder = new PowerAuthSDK.Builder(powerAuthConfiguration);
+        PowerAuthSDK powerAuthSDK = builder
+                .clientConfiguration(srcClientConfiguration)
+                .build(RuntimeEnvironment.systemContext);
+
+        assertNotNull(powerAuthSDK);
+        assertNotNull(powerAuthSDK.getConfiguration());
+
+        Field clientConfigurationField = powerAuthSDK.getClass().getDeclaredField("mClientConfiguration");
+        clientConfigurationField.setAccessible(true);
+        PowerAuthClientConfiguration powerAuthClientConfiguration = (PowerAuthClientConfiguration) clientConfigurationField.get(powerAuthSDK);
+        assertNotNull(powerAuthClientConfiguration);
+        assertEquals(srcClientConfiguration, powerAuthClientConfiguration);
+
+        Field pa2ClientField = powerAuthSDK.getClass().getDeclaredField("mClient");
+        pa2ClientField.setAccessible(true);
+        PA2Client pa2Client = (PA2Client) pa2ClientField.get(powerAuthSDK);
+        assertNotNull(pa2Client);
+
+        PowerAuthClientConfiguration powerAuthClientConfigurationInClient = pa2Client.getClientConfiguration();
+        assertNotNull(powerAuthClientConfigurationInClient);
+        assertEquals(srcClientConfiguration, powerAuthClientConfigurationInClient);
+
+        assertEquals(powerAuthClientConfiguration, powerAuthClientConfigurationInClient);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/shadow/ShadowDefaultSavePowerAuthStateListener.java
+++ b/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/shadow/ShadowDefaultSavePowerAuthStateListener.java
@@ -1,0 +1,27 @@
+package io.getlime.security.powerauth.shadow;
+
+import android.support.annotation.Nullable;
+
+import org.robolectric.annotation.Implements;
+
+import io.getlime.security.powerauth.networking.response.ISavePowerAuthStateListener;
+import io.getlime.security.powerauth.sdk.impl.DefaultSavePowerAuthStateListener;
+
+/**
+ * Shadow class (Robolectric mock) of {@link DefaultSavePowerAuthStateListener}.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@Implements(DefaultSavePowerAuthStateListener.class)
+public class ShadowDefaultSavePowerAuthStateListener implements ISavePowerAuthStateListener {
+
+    @Override
+    public byte[] serializedState(String instanceId) {
+        return new byte[0];
+    }
+
+    @Override
+    public void onPowerAuthStateChanged(@Nullable String instanceId, byte[] serializedState) {
+
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/shadow/ShadowSession.java
+++ b/proj-android/PowerAuthLibrary/src/test/java/io/getlime/security/powerauth/shadow/ShadowSession.java
@@ -1,0 +1,17 @@
+package io.getlime.security.powerauth.shadow;
+
+import org.robolectric.annotation.Implements;
+
+import io.getlime.security.powerauth.core.Session;
+
+/**
+ * Shadow class (Robolectric mock) of {@link Session}.
+ *
+ * @author Tomas Kypta, tomas.kypta@wultra.com
+ */
+@Implements(Session.class)
+public class ShadowSession {
+
+    public ShadowSession() {}
+
+}


### PR DESCRIPTION
Also added unit tests based on Robolectric to test the fix.