### PR TITLE
Core: Fixed #169: Removed "migration" terminology from the code base

### DIFF
--- a/include/PowerAuth/PublicTypes.h
+++ b/include/PowerAuth/PublicTypes.h
@@ -516,7 +516,7 @@ namespace powerAuth
 		 */
 		cc7::byte currentVersion;
 		/**
-		 If different than `currentVersion`, then activation migration is available.
+		 If greater than `currentVersion`, then activation upgrade is available.
 		 */
 		cc7::byte upgradeVersion;
 		
@@ -533,9 +533,9 @@ namespace powerAuth
 		}
 		
 		/**
-		 Returns true if migration to a new activation data is possible.
+		 Returns true if upgrade to a new activation data is possible.
 		 */
-		bool isMigrationAvailable() const;
+		bool isProtocolUpgradeAvailable() const;
 	};
 	
 	
@@ -565,10 +565,10 @@ namespace powerAuth
 	
 	
 	//
-	// MARK: - Migration -
+	// MARK: - Protocol upgrade -
 	//
 	
-	struct MigrationData
+	struct ProtocolUpgradeData
 	{
 		struct V3
 		{

--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -115,9 +115,9 @@ namespace powerAuth
 		bool hasValidActivation() const;
 		
 		/**
-		 Returns true if the session has a pending protocol migration to a newer version.
+		 Returns true if the session has a pending protocol upgrade to a newer version.
 		 */
-		bool hasPendingActivationMigration() const;
+		bool hasPendingProtocolUpgrade() const;
 		
 		/**
 		 Returns version of protocol in which the session currently operates. The version is determined by the
@@ -507,63 +507,63 @@ namespace powerAuth
 		
 	public:
 		
-		// MARK: - Protocol migration -
+		// MARK: - Protocol upgrade -
 
 		
 		/**
-		 Formally starts the protocol migration to a newer version. The function only sets flag
-		 indicating that migration to the next protocol version is in progress. You should serialize
-		 an activation status after this call. The version to which the migration has been started can be
-		 determined by calling `pendingActivationMigrationVersion()`.
+		 Formally starts the protocol upgrade to a newer version. The function only sets flag
+		 indicating that upgrade to the next protocol version is in progress. You should serialize
+		 an activation status after this call. The version to which the upgrade has been started can be
+		 determined by calling `pendingActivationUpgradeVersion()`.
 		 
-		 Note that some tasks provided by the session may be temporarily disabled durng
-		 the migration.
+		 Note that some tasks provided by the session may be temporarily disabled during
+		 the protocol upgrade.
 		 
 		 Returns EC_Ok			if operation succeeded.
 		 		 EC_WrongState	if called in wrong session state
 		 */
-		ErrorCode startMigration();
+		ErrorCode startProtocolUpgrade();
 		
 		/**
-		 Determines which version of the protocol is the session being migrated to.
+		 Determines which version of the protocol is the session being upgraded to.
 		 
 		 Returns Version_NA		if there's no valid activation, or
-		 						if there's no pending migration
-		 		 Version_Vx		if there's pending migration to protocol version.
+		 						if there's no pending protocol ugprade
+		 		 Version_Vx		if there's pending upgrade to protocol version.
 		 */
-		Version pendingActivationMigrationVersion() const;
+		Version pendingProtocolUpgradeVersion() const;
 		
 		/**
-		 Applies |migration_data| to the session. The |migration_data| structure must contain
-		 all required information for migration _from_ current state to a new one. For example,
-		 if session is in V2 protocol version, then the structure must contain data for migration
+		 Applies |upgrade_data| to the session. The |upgrade_data| structure must contain
+		 all required information for upgrade _from_ current state to a new one. For example,
+		 if session is in V2 protocol version, then the structure must contain data for upgrade
 		 from V2 to V3 (typically named as `toV3`).
 		 
-		 Note that this method doesn't clear pending migration status. You need to call |finishMigration|
-		 to clear that pending flag, or repeat migration data applying, if session needs to be migrated
+		 Note that this method doesn't clear pending upgrade status. You need to call |finishProtocolUpgrade|
+		 to clear that pending flag, or repeat upgrade data applying, if session needs to be upgraded
 		 over the various versions.
 		 
 		 Returns EC_Ok			if operation succeeded and session has been successfully
-		 						migrated to new protocol version.
-		 		 EC_WrongState	if migration is not required, or
-		 						if migration to appropriate version was not started, or
+		 						upgraded to new protocol version.
+		 		 EC_WrongState	if upgrade is not required, or
+		 						if upgrade to appropriate version was not started, or
 		 						if session has no valid activation.
-		 		 EC_WrongParam	if migration data contains invalid data.
+		 		 EC_WrongParam	if upgrade data contains invalid data.
 		 */
-		ErrorCode applyMigrationData(const MigrationData & migration_data);
+		ErrorCode applyProtocolUpgradeData(const ProtocolUpgradeData & upgrade_data);
 
 		/**
-		 Formally ends the protocol migration. The function resets flag indicating that migration
-		 to the next protocol version is in progress. The reset is possible only if the migration
-		 was successful (e.g. when migrating to V3, the protocol version is now V3)
+		 Formally ends the protocol upgrade procedure. The function resets flag indicating that ugprade
+		 to the next protocol version is in progress. The reset is possible only if the upgrade
+		 was successful (e.g. when upgrading to V3, the protocol version is now V3)
 		 
 		 You should serialize an activation status ater this call.
 		 
 		 Returns EC_Ok			if operation succeeded.
 		 		 EC_WrongState	if called in wrong session state, or
-		 						if migration was not completed properly.
+		 						if upgrade was not completed properly.
 		 */
-		ErrorCode finishMigration();
+		ErrorCode finishProtocolUpgrade();
 		
 	public:
 		

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ProtocolUpgradeData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ProtocolUpgradeData.java
@@ -32,10 +32,10 @@ public class ProtocolUpgradeData {
     public final String v3CtrData;
 
     /**
-     * Constructs data for migration to V3 protocol.
+     * Constructs data for upgrade to V3 protocol.
      *
      * @param ctrData initial value for hash-based counter. Base64 string is expected.
-     * @return migration data constructed for migration to V3 protocol version
+     * @return data constructed for upgrade to V3 protocol version
      */
     public static @NonNull ProtocolUpgradeData version3(@NonNull String ctrData) {
         return new ProtocolUpgradeData(ProtocolVersion.V3, ctrData);
@@ -44,7 +44,7 @@ public class ProtocolUpgradeData {
     /**
      * Private constructor
      *
-     * @param toVersion specifies version of data for migration
+     * @param toVersion specifies version of data for upgrade
      * @param v3CtrData initial value for hash-based counter
      */
     private ProtocolUpgradeData(ProtocolVersion toVersion, @Nullable String v3CtrData) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
@@ -562,8 +562,8 @@ public class Session {
     public native int startProtocolUpgrade();
 
     /**
-     * Applies migration data to the session. You need to construct migration data object
-     * to match the migration from current protocol version, to the upgraded one.
+     * Applies protocol upgrade data to the session. You need to construct upgrade data object
+     * to match the upgrade from current protocol version, to the upgraded one.
      *
      * Returns integer comparable to constants from ErrorCode class. If ErrorCode.OK is returned
      * then the operation succeeded.

--- a/proj-xcode/Classes/core/PA2PrivateImpl.h
+++ b/proj-xcode/Classes/core/PA2PrivateImpl.h
@@ -55,7 +55,7 @@
 @end
 
 @protocol PA2ProtocolUpgradeDataPrivate <PA2ProtocolUpgradeData>
-- (void) setupStructure:(io::getlime::powerAuth::MigrationData &)ref;
+- (void) setupStructure:(io::getlime::powerAuth::ProtocolUpgradeData &)ref;
 @end
 
 /**

--- a/proj-xcode/Classes/core/PA2ProtocolUpgradeData.mm
+++ b/proj-xcode/Classes/core/PA2ProtocolUpgradeData.mm
@@ -26,7 +26,7 @@
 
 @implementation PA2ProtocolUpgradeDataV3 (Private)
 
-- (void) setupStructure:(io::getlime::powerAuth::MigrationData &)ref
+- (void) setupStructure:(io::getlime::powerAuth::ProtocolUpgradeData &)ref
 {
 	ref.toV3.ctrData = cc7::objc::CopyFromNSString(_ctrData);
 }

--- a/proj-xcode/Classes/core/PA2Session.h
+++ b/proj-xcode/Classes/core/PA2Session.h
@@ -503,7 +503,7 @@
 /**
  Formally ends the protocol upgrade. The function resets flag indicating that upgrade
  to the next protocol version is in progress. The reset is possible only if the upgrade
- was successful (e.g. when migrating to V3, the protocol version is now V3)
+ was successful (e.g. when upgrading to V3, the protocol version is now V3)
  
  You should serialize an activation status ater this call.
  

--- a/proj-xcode/Classes/core/PA2Session.mm
+++ b/proj-xcode/Classes/core/PA2Session.mm
@@ -111,7 +111,7 @@ using namespace io::getlime::powerAuth;
 
 - (BOOL) hasPendingProtocolUpgrade
 {
-	return _session->hasPendingActivationMigration();
+	return _session->hasPendingProtocolUpgrade();
 }
 
 - (PA2ProtocolVersion) protocolVersion
@@ -409,14 +409,14 @@ using namespace io::getlime::powerAuth;
 
 - (BOOL) startProtocolUpgrade
 {
-	ErrorCode error = _session->startMigration();
+	ErrorCode error = _session->startProtocolUpgrade();
 	PA2Objc_DebugDumpError(self, @"StartProtocolUpgrade", error);
 	return error == EC_Ok;
 }
 
 - (PA2ProtocolVersion) pendingProtocolUpgradeVersion
 {
-	return (PA2ProtocolVersion) _session->pendingActivationMigrationVersion();
+	return (PA2ProtocolVersion) _session->pendingProtocolUpgradeVersion();
 }
 
 - (BOOL) applyProtocolUpgradeData:(nonnull id<PA2ProtocolUpgradeData>)upgradeData
@@ -425,9 +425,9 @@ using namespace io::getlime::powerAuth;
 	if ([upgradeData conformsToProtocol:@protocol(PA2ProtocolUpgradeDataPrivate)]) {
 		id<PA2ProtocolUpgradeDataPrivate> upgradeDataObject = (id<PA2ProtocolUpgradeDataPrivate>)upgradeData;
 		// Convert data to C++ & commit to underlying session
-		MigrationData cpp_migration_data;
-		[upgradeDataObject setupStructure:cpp_migration_data];
-		error = _session->applyMigrationData(cpp_migration_data);
+		ProtocolUpgradeData cpp_upgrade_data;
+		[upgradeDataObject setupStructure:cpp_upgrade_data];
+		error = _session->applyProtocolUpgradeData(cpp_upgrade_data);
 	} else {
 		error = EC_WrongParam;
 	}
@@ -437,7 +437,7 @@ using namespace io::getlime::powerAuth;
 
 - (BOOL) finishProtocolUpgrade
 {
-	ErrorCode error = _session->finishMigration();
+	ErrorCode error = _session->finishProtocolUpgrade();
 	PA2Objc_DebugDumpError(self, @"FinishProtocolUpgrade", error);
 	return error == EC_Ok;
 }

--- a/proj-xcode/Classes/core/PA2Types.mm
+++ b/proj-xcode/Classes/core/PA2Types.mm
@@ -228,7 +228,7 @@ const PA2SignatureFactor PA2SignatureFactor_Possession_Knowledge_Biometry	= SF_P
 			status_str = @"<<unknown>>"; break;
 			
 	}
-	bool upgrade = _status.isMigrationAvailable();
+	bool upgrade = _status.isProtocolUpgradeAvailable();
 	return [NSString stringWithFormat:@"<PA2ActivationStatus %@, fails %@/%@%@>", status_str, @(_status.failCount), @(_status.maxFailCount), upgrade ? @", upgrade" : @""];
 }
 #endif
@@ -247,7 +247,7 @@ const PA2SignatureFactor PA2SignatureFactor_Possession_Knowledge_Biometry	= SF_P
 
 - (BOOL) isProtocolUpgradeAvailable
 {
-	return _status.isMigrationAvailable();
+	return _status.isProtocolUpgradeAvailable();
 }
 
 @end

--- a/src/PowerAuth/PublicTypes.cpp
+++ b/src/PowerAuth/PublicTypes.cpp
@@ -107,7 +107,7 @@ namespace powerAuth
 	// MARK: - ActivationStatus -
 	//
 	
-	bool ActivationStatus::isMigrationAvailable() const
+	bool ActivationStatus::isProtocolUpgradeAvailable() const
 	{
 		if (currentVersion < upgradeVersion) {
 			return upgradeVersion <= MaxSupported;

--- a/src/PowerAuth/jni/SessionJNI.cpp
+++ b/src/PowerAuth/jni/SessionJNI.cpp
@@ -360,7 +360,7 @@ CC7_JNI_METHOD_PARAMS(jobject, decodeActivationStatus, jstring statusBlob, jobje
 		CC7_JNI_SET_FIELD_INT	(resultObject, resultClazz, "maxFailCount",			cppStatus.maxFailCount);
 		CC7_JNI_SET_FIELD_OBJECT(resultObject, resultClazz, "currentVersion", versionSig, currentVersionObject);
 		CC7_JNI_SET_FIELD_OBJECT(resultObject, resultClazz, "upgradeVersion", versionSig, upgradeVersionObject);
-		CC7_JNI_SET_FIELD_BOOL	(resultObject, resultClazz, "isUpgradeAvailable",	cppStatus.isMigrationAvailable());
+		CC7_JNI_SET_FIELD_BOOL	(resultObject, resultClazz, "isUpgradeAvailable",	cppStatus.isProtocolUpgradeAvailable());
 	}
 	return resultObject;
 }
@@ -719,7 +719,7 @@ CC7_JNI_METHOD(jbyteArray, generateSignatureUnlockKey)
 
 
 // ----------------------------------------------------------------------------
-// Protocol migration
+// Protocol upgrade
 // ----------------------------------------------------------------------------
 
 //
@@ -732,7 +732,7 @@ CC7_JNI_METHOD(jboolean, hasPendingProtocolUpgrade)
 		CC7_ASSERT(false, "Missing internal handle.");
 		return false;
 	}
-	return (jboolean) session->hasPendingActivationMigration();
+	return (jboolean) session->hasPendingProtocolUpgrade();
 }
 
 //
@@ -743,7 +743,7 @@ CC7_JNI_METHOD(jobject, getPendingProtocolUpgradeVersion)
 	auto session = CC7_THIS_OBJ();
 	Version v;
 	if (session) {
-		v = session->pendingActivationMigrationVersion();
+		v = session->pendingProtocolUpgradeVersion();
 	} else {
 		v = Version_NA;
 	}
@@ -760,7 +760,7 @@ CC7_JNI_METHOD(jint, startProtocolUpgrade)
 		CC7_ASSERT(false, "Missing internal handle.");
 		return EC_WrongParam;
 	}
-	return (jint) session->startMigration();
+	return (jint) session->startProtocolUpgrade();
 }
 
 //
@@ -778,12 +778,12 @@ CC7_JNI_METHOD_PARAMS(jint, applyProtocolUpgradeData, jobject md)
 	jclass mdClazz = CC7_JNI_MODULE_FIND_CLASS("ProtocolUpgradeData");
 	auto cpp_version = (Version) CC7_JNI_GET_FIELD_INT(md, mdClazz, "toVersion");
 
-	MigrationData cpp_md;
+	ProtocolUpgradeData cpp_upd;
 	if (cpp_version == Version_V3) {
 		// Load V3 fields...
-		cpp_md.toV3.ctrData = cc7::jni::CopyFromJavaString(env, CC7_JNI_GET_FIELD_STRING(md, mdClazz, "v3CtrData"));
+		cpp_upd.toV3.ctrData = cc7::jni::CopyFromJavaString(env, CC7_JNI_GET_FIELD_STRING(md, mdClazz, "v3CtrData"));
 	}
-	return (jint) session->applyMigrationData(cpp_md);
+	return (jint) session->applyProtocolUpgradeData(cpp_upd);
 }
 
 //
@@ -796,7 +796,7 @@ CC7_JNI_METHOD(jint, finishProtocolUpgrade)
 		CC7_ASSERT(false, "Missing internal handle.");
 		return EC_WrongParam;
 	}
-	return (jint) session->finishMigration();
+	return (jint) session->finishProtocolUpgrade();
 }
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuth/protocol/PrivateTypes.h
+++ b/src/PowerAuth/protocol/PrivateTypes.h
@@ -181,9 +181,9 @@ namespace protocol
 			 */
 			cc7::U32	usesExternalKey			: 1;
 			/**
-			 Bits reserved for current pending migration
+			 Bits reserved for current pending protocol upgrade
 			 */
-			cc7::U32	pendingMigration		: 8;
+			cc7::U32	pendingUpgradeVersion		: 8;
 		};
 		union {
 			_Flags		flags;

--- a/src/PowerAuthTests/pa2SessionTests.cpp
+++ b/src/PowerAuthTests/pa2SessionTests.cpp
@@ -51,7 +51,7 @@ namespace powerAuthTests
 			CC7_REGISTER_TEST_METHOD(testActivationWithEEKUsingSetter);
 			CC7_REGISTER_TEST_METHOD(testServerSignedData);
 			CC7_REGISTER_TEST_METHOD(testOldDataMigration);
-			CC7_REGISTER_TEST_METHOD(testPersistentDataMigrationToV3);
+			CC7_REGISTER_TEST_METHOD(testPersistentDataUpgradeToV3);
 		}
 		
 		EC_KEY *	_masterServerPrivateKey;
@@ -1032,7 +1032,7 @@ namespace powerAuthTests
 			}
 		}
 		
-		void testPersistentDataMigrationToV3()
+		void testPersistentDataUpgradeToV3()
 		{
 			// constants
 			std::string master_server_public_key  = "AuCDGp3fAHL695yWxCP6d+jZEzwZleOdmCU+qFIImjBs";
@@ -1059,25 +1059,25 @@ namespace powerAuthTests
 			ccstAssertFalse(s1.hasPendingActivation());
 			ccstAssertFalse(s1.hasExternalEncryptionKey());
 			ccstAssertEqual(s1.activationIdentifier(), "FULL-BUT-FAKE-ACTIVATION-ID");
-			ccstAssertEqual(Version_NA, s1.pendingActivationMigrationVersion());
+			ccstAssertEqual(Version_NA, s1.pendingProtocolUpgradeVersion());
 
-			ec = s1.startMigration();
+			ec = s1.startProtocolUpgrade();
 			ccstAssertEqual(ec, EC_Ok);
-			ccstAssertEqual(Version_V3, s1.pendingActivationMigrationVersion());
+			ccstAssertEqual(Version_V3, s1.pendingProtocolUpgradeVersion());
 			
-			// Apply migration data
-			MigrationData migration_data;
-			migration_data.toV3.ctrData = crypto::GetRandomData(16).base64String();
-			ec = s1.applyMigrationData(migration_data);
+			// Apply protocol upgrade data
+			ProtocolUpgradeData upgrade_data;
+			upgrade_data.toV3.ctrData = crypto::GetRandomData(16).base64String();
+			ec = s1.applyProtocolUpgradeData(upgrade_data);
 			ccstAssertTrue(ec == EC_Ok);
 			ccstAssertEqual(s1.protocolVersion(), Version_V3);
-			ccstAssertEqual(Version_V3, s1.pendingActivationMigrationVersion());
+			ccstAssertEqual(Version_V3, s1.pendingProtocolUpgradeVersion());
 			
-			// Now finish the migration
-			ec = s1.finishMigration();
+			// Now finish the upgrade
+			ec = s1.finishProtocolUpgrade();
 			ccstAssertTrue(ec == EC_Ok);
 			ccstAssertEqual(s1.protocolVersion(), Version_V3);
-			ccstAssertEqual(Version_NA, s1.pendingActivationMigrationVersion());
+			ccstAssertEqual(Version_NA, s1.pendingProtocolUpgradeVersion());
 			
 			// Try to save, reset & reload data
 			cc7::ByteArray v3_data = s1.saveSessionState();


### PR DESCRIPTION
This PR removes "migration" terminology from the low level C++ code and from several related high level classes in Java & ObjC. We're using "protocol upgrade" term as a right replacement. 

So, most of the changes are in the documentation, plus several methods needed to be renamed.