### PR TITLE
Fixed #171: Added interface to synchronize application's signed requests

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClient.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClient.java
@@ -39,9 +39,9 @@ import io.getlime.security.powerauth.sdk.impl.IPrivateCryptoHelper;
  */
 public class HttpClient {
 
-    private final PowerAuthClientConfiguration configuration;
-    private final String baseUrl;
-    private final IExecutorProvider executorProvider;
+    private final @NonNull PowerAuthClientConfiguration configuration;
+    private final @NonNull String baseUrl;
+    private final @NonNull IExecutorProvider executorProvider;
 
     /**
      * @param configuration HTTP client configuration
@@ -60,15 +60,23 @@ public class HttpClient {
     /**
      * @return HTTP client configuration assigned to this object
      */
-    public PowerAuthClientConfiguration getClientConfiguration() {
+    public @NonNull PowerAuthClientConfiguration getClientConfiguration() {
         return configuration;
     }
 
     /**
      * @return String with base URL to PowerAuth Server REST API
      */
-    public String getBaseUrl() {
+    public @NonNull String getBaseUrl() {
         return baseUrl;
+    }
+
+
+    /**
+     * @return {@link IExecutorProvider} object assigned during the client initialization.
+     */
+    public @NonNull IExecutorProvider getExecutorProvider() {
+        return executorProvider;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IAsyncOperation.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IAsyncOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.networking.interfaces;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
+
+/**
+ * The {@code IAsyncOperation} provides a simple interface for cancellable asynchronous operation,
+ * executed typically on the background thread.
+ *
+ * @see ICancelable
+ */
+public interface IAsyncOperation {
+
+    /**
+     * Called when operation is going to be executed on the worker thread.
+     * The implementor has following responsibilities:
+     * <ul>
+     *     <li>
+     *         Must call {@link ICancelable#cancel()} on provided {@code cancelable} object,
+     *         when its asynchronous job is done.
+     *     </li>
+     *     <li>
+     *         Optionally, can periodically check whether {@link ICancelable#isCancelled()}
+     *         returns {@code true} to check if operation has been cancelled from an external code.
+     *     </li>
+     * </ul>
+     *
+     * It doesn't matter whether the job is really an asynchronous or is executed completely inside
+     * the {@code onExecution()}, the {@code cancel()} method has to be called at some point.
+     * Otherwise the worker thread will be blocked indefinitely.
+     *
+     * @param cancelable {@link ICancelable} object, implementor must call {@link ICancelable#cancel()}
+     *                   after the operation is completed.
+     */
+    @WorkerThread
+    void onExecution(@NonNull final ICancelable cancelable);
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.sdk;
 
 import android.content.Context;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
@@ -60,6 +61,7 @@ import io.getlime.security.powerauth.networking.endpoints.CreateActivationEndpoi
 import io.getlime.security.powerauth.networking.endpoints.RemoveActivationEndpoint;
 import io.getlime.security.powerauth.networking.endpoints.ValidateSignatureEndpoint;
 import io.getlime.security.powerauth.networking.endpoints.VaultUnlockEndpoint;
+import io.getlime.security.powerauth.networking.interfaces.IAsyncOperation;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.networking.interfaces.INetworkResponseListener;
 import io.getlime.security.powerauth.networking.response.IActivationRemoveListener;
@@ -69,6 +71,7 @@ import io.getlime.security.powerauth.networking.response.IChangePasswordListener
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener;
 import io.getlime.security.powerauth.networking.response.IDataSignatureListener;
 import io.getlime.security.powerauth.networking.response.IFetchEncryptionKeyListener;
+import io.getlime.security.powerauth.networking.response.IValidatePasswordListener;
 import io.getlime.security.powerauth.rest.api.model.entity.ActivationType;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
 import io.getlime.security.powerauth.rest.api.model.request.v3.ActivationLayer2Request;
@@ -76,10 +79,10 @@ import io.getlime.security.powerauth.rest.api.model.request.v3.VaultUnlockReques
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
 import io.getlime.security.powerauth.rest.api.model.response.v3.ActivationLayer2Response;
 import io.getlime.security.powerauth.rest.api.model.response.v3.VaultUnlockResponsePayload;
+import io.getlime.security.powerauth.sdk.impl.CancelableAsynchronousOperation;
 import io.getlime.security.powerauth.sdk.impl.DefaultExecutorProvider;
 import io.getlime.security.powerauth.sdk.impl.GetActivationStatusTask;
 import io.getlime.security.powerauth.sdk.impl.ISavePowerAuthStateListener;
-import io.getlime.security.powerauth.networking.response.IValidatePasswordListener;
 import io.getlime.security.powerauth.sdk.impl.DefaultSavePowerAuthStateListener;
 import io.getlime.security.powerauth.sdk.impl.IPrivateCryptoHelper;
 import io.getlime.security.powerauth.sdk.impl.VaultUnlockReason;
@@ -1637,5 +1640,71 @@ public class PowerAuthSDK {
     public @Nullable EciesEncryptor getEciesEncryptorForActivationScope(@NonNull final Context context) throws PowerAuthErrorException {
         final IPrivateCryptoHelper helper = getCryptoHelper(context);
         return helper.getEciesEncryptor(EciesEncryptorId.GENERIC_ACTIVATION_SCOPE);
+    }
+
+    // Request synchronization
+
+    /**
+     * Executes provided {@link IAsyncOperation} on an internal, serialized thread executor. This gives application an opportunity to serialize
+     * its own signed HTTP requests, with requests created in the SDK internally.
+     *
+     * <h3>Why this matters</h3>
+     *
+     * The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
+     * at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+     * to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
+     * them with the SDK.
+     *
+     * <h3>Recommended practices</h3>
+     * <ul>
+     *     <li>You should calculate PowerAuth signature from the {@link IAsyncOperation#onExecution(ICancelable)} method.
+     *     <li>You have to always call {@code cancel()} on provided {@link ICancelable} object once the operation is finished,
+     *         otherwise the thread will be blocked indefinitely.
+     *     <li>It doesn't matter whether the actual HTTP request is performed directly in {@code onExecution()} method, or you'll use
+     *         your own thread. What's matter is to call {@code cancel()} once the operation is done.
+     * </ul>
+     *
+     * Check the documentation for {@link IAsyncOperation} for more details.
+     *
+     * @param asynchronousOperation {@link IAsyncOperation} to be executed on a serialized thread executor.
+     * @return {@link ICancelable} object, allowing the external cancellation.
+     * @throws PowerAuthErrorException if there's not a valid activation.
+     */
+    public @NonNull ICancelable executeOnSerialExecutor(@NonNull final IAsyncOperation asynchronousOperation) throws PowerAuthErrorException {
+        final CancelableAsynchronousOperation operation = new CancelableAsynchronousOperation(asynchronousOperation);
+        executeOnSerialExecutor(operation);
+        return operation;
+    }
+
+    /**
+     * Executes provided {@link Runnable} object on the internal, serialized thread executor. This gives application an opportunity to serialize
+     * its own signed HTTP requests, with requests created in the SDK internally.
+     *
+     * <h3>Why this matters</h3>
+     *
+     * The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
+     * at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+     * to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
+     * them with the SDK.
+     *
+     * <h3>Recommended practices</h3>
+     * <ul>
+     *     <li>You should calculate PowerAuth signature from the {@link Runnable#run()} method.
+     *     <li>{@link Runnable#run()} should return from its execution after the HTTP request is fully processed, or at least after
+     *         the response headers are received (e.g. you know that server already did process the request)
+     * </ul>
+     *
+     * Unlike the {@link #executeOnSerialExecutor(IAsyncOperation)} method, this variant is more generic. You can, for example, execute
+     * your own networking {@link AsyncTask} directly, but be aware that the PowerAuth signature should be calculated in {@link AsyncTask#doInBackground(Object[])}
+     * method.
+     *
+     * @param runnable {@link Runnable} operation to be executed on a serialized thread executor.
+     * @throws PowerAuthErrorException if there's not a valid activation.
+     */
+    public void executeOnSerialExecutor(@NonNull final Runnable runnable) throws PowerAuthErrorException {
+        if (!hasValidActivation()) {
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeInvalidActivationState, "Missing activation");
+        }
+        mClient.getExecutorProvider().getSerialExecutor().execute(runnable);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CancelableAsynchronousOperation.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CancelableAsynchronousOperation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk.impl;
+
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Semaphore;
+
+import io.getlime.security.powerauth.networking.interfaces.IAsyncOperation;
+import io.getlime.security.powerauth.networking.interfaces.ICancelable;
+
+/**
+ * The {@code CancelableAsynchronousOperation} class allows execution of {@link IAsyncOperation}
+ * on the background thread. The operation itself also implements {@link ICancelable} interface and
+ * therefore the same instance is provided as parameter to the {@link IAsyncOperation#onExecution(ICancelable)}.
+ *
+ * @see ICancelable
+ * @see IAsyncOperation
+ */
+public class CancelableAsynchronousOperation implements Runnable, ICancelable {
+
+    private final @NonNull IAsyncOperation asyncOperation;
+    private final Semaphore semaphore = new Semaphore(0, false);
+    private boolean cancelled = false;
+
+    /**
+     * @param asyncOperation operation to be executed on the background thread.
+     */
+    public CancelableAsynchronousOperation(final @NonNull IAsyncOperation asyncOperation) {
+        this.asyncOperation = asyncOperation;
+    }
+
+    @Override
+    public void cancel() {
+        // Release semaphore only for a first call
+        final boolean releaseSemaphore = !cancelled;
+        cancelled = true;
+        if (releaseSemaphore) {
+            semaphore.release();
+        }
+    }
+
+    @Override
+    public synchronized boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void run() {
+        // Check whether the operation has been already cancelled.
+        if (isCancelled()) {
+            return;
+        }
+        // Execute operation
+        asyncOperation.onExecution(this);
+        // And wait for cancellation signal
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            // Do nothing...
+        }
+    }
+}

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.h
@@ -454,3 +454,55 @@
 
 @end
 
+
+#pragma mark - Request synchronization
+
+@interface PowerAuthSDK (RequestSync)
+
+/**
+ Executes provided block on an internal, serialized operation queue. This gives application an opportunity to serialize
+ its own signed HTTP requests, with requests created in the SDK internally.
+ 
+ @b Why this matters
+ 
+ The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
+ at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+ to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
+ them with the SDK.
+ 
+ @b Recommended practices
+ 
+ 1)  You should calculate PowerAuth signature from the execute block method.
+ 
+ 2)  You have to always call `task.cancel()` on provided `PA2OperationTask` object once the operation is finished,
+     otherwise the seriali queue will be blocked indefinitely.
+
+ @param execute Block to be executed in the serialized queue.
+ @return Cancelable operation task, or nil if there's no activation.
+ */
+- (nullable id<PA2OperationTask>) executeBlockOnSerialQueue:(void(^ _Nonnull)(id<PA2OperationTask> _Nonnull task))execute;
+
+/**
+ Executes provided operation on an internal, serialized operation queue. This gives application an opportunity to serialize
+ its own signed HTTP requests, with requests created in the SDK internally.
+ 
+ @b Why this matters
+ 
+ The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
+ at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+ to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
+ them with the SDK.
+ 
+ @b Recommended practices
+ 
+ You should calculate PowerAuth signature after the operation is started. If you calculate the signature before and after that you add
+ that operation to the queue, the logical counter may not be synchronized properly.
+ 
+ 
+
+ @param operation Operation to be executed in the serialized queue
+ @return YES if operation was added to the queue, or NO if there's no activation.
+ */
+- (BOOL) executeOperationOnSerialQueue:(nonnull NSOperation *)operation;
+
+@end


### PR DESCRIPTION
This PR adds a new interface to PowerAuthSDK, allowing application to synchronize its signed requests with requests created in SDK internally. Change adds this functionality to both platforms.