### PR TITLE
Removed "2.0" protocol naming from documentation comments.

### DIFF
--- a/include/PowerAuth/PublicTypes.h
+++ b/include/PowerAuth/PublicTypes.h
@@ -320,7 +320,7 @@ namespace powerAuth
 	struct HTTPRequestDataSignature
 	{
 		/**
-		 Version of PowerAuth protocol. Current value is "2.0"
+		 Version of PowerAuth protocol.
 		 */
 		std::string version;
 		/**

--- a/proj-xcode/Classes/core/PA2Types.h
+++ b/proj-xcode/Classes/core/PA2Types.h
@@ -267,7 +267,7 @@ extern const PA2SignatureFactor PA2SignatureFactor_Possession_Knowledge_Biometry
 @interface PA2HTTPRequestDataSignature : NSObject
 
 /**
- Version of PowerAuth protocol. Current value is "2.0"
+ Version of PowerAuth protocol.
  */
 @property (nonatomic, strong, nonnull, readonly) NSString * version;
 /**

--- a/proj-xcode/Classes/networking/private/request/PA2Request.h
+++ b/proj-xcode/Classes/networking/private/request/PA2Request.h
@@ -17,7 +17,7 @@
 #import "PA2Codable.h"
 
 /**
- Class representing a generic PowerAuth 2.0 Standard API requests.
+ Class representing a generic PowerAuth Standard API requests.
  
  Client classes are supposed to create a new object using 'initWithDictionary:requestObjectType:'
  method and serialize request objects using 'toDictionary' method.
@@ -33,7 +33,7 @@
 
 /**
  Serialize request object to the dictionary that is ready to be serialized to the correct
- JSON representation for the use in PowerAuth 2.0 Standard API.
+ JSON representation for the use in PowerAuth Standard API.
  
  @return Dictionary representing the request object.
  */

--- a/proj-xcode/Classes/networking/private/response/PA2Response.h
+++ b/proj-xcode/Classes/networking/private/response/PA2Response.h
@@ -17,7 +17,7 @@
 #import "PA2Error+Decodable.h"
 #import "PA2RestResponseStatus.h"
 
-/** Class representing a generic PowerAuth 2.0 Standard API response.
+/** Class representing a generic PowerAuth Standard API response.
  
  Client classes are supposed to create a new object using 'initWithDictionary:responseObjectType:'
  method and serialize response objects using 'toDictionary' method.
@@ -38,7 +38,7 @@
 @property (nonatomic, strong) PA2Error * responseError;
 
 /**
- Initializes a new response from given dictionary (as it is received from PowerAuth 2.0 Standard RESTful API)
+ Initializes a new response from given dictionary (as it is received from PowerAuth Standard RESTful API)
  using a given response object type.
  
  @param dictionary A dictionary with response object information.

--- a/proj-xcode/Classes/networking/public/PA2AuthorizationHttpHeader.h
+++ b/proj-xcode/Classes/networking/public/PA2AuthorizationHttpHeader.h
@@ -23,14 +23,14 @@
 @interface PA2AuthorizationHttpHeader : NSObject
 
 /**
- Property representing PowerAuth 2.0 HTTP Authorization Header. The current implementation
+ Property representing PowerAuth HTTP Authorization Header. The current implementation
  contains value "X-PowerAuth-Authorization" for standard authorization and "X-PowerAuth-Token" for
  token-based authorization.
  */
 @property (nonatomic, strong, readonly, nonnull) NSString *key;
 
 /**
- Computed value of the PowerAuth 2.0 HTTP Authorization Header, to be used in HTTP requests "as is".
+ Computed value of the PowerAuth HTTP Authorization Header, to be used in HTTP requests "as is".
  */
 @property (nonatomic, strong, readonly, nonnull) NSString *value;
 

--- a/proj-xcode/Classes/networking/public/PA2ErrorResponse.h
+++ b/proj-xcode/Classes/networking/public/PA2ErrorResponse.h
@@ -18,7 +18,7 @@
 #import "PA2Error.h"
 
 /**
- Class representing an error PowerAuth 2.0 Standard API response.
+ Class representing an error reponse received from PowerAuth Standard RESTful API.
  */
 @interface PA2ErrorResponse : NSObject
 

--- a/proj-xcode/Classes/sdk/PowerAuthConfiguration.h
+++ b/proj-xcode/Classes/sdk/PowerAuthConfiguration.h
@@ -24,19 +24,19 @@
  */
 @property (nonatomic, strong, nonnull) NSString	*instanceId;
 
-/** Base URL to the PowerAuth 2.0 Standard RESTful API (the URL part before "/pa/...").
+/** Base URL to the PowerAuth Standard RESTful API (the URL part before "/pa/...").
  */
 @property (nonatomic, strong, nonnull) NSString	*baseEndpointUrl;
 
-/** APPLICATION_KEY as defined in PowerAuth 2.0 specification - a key identifying an application version.
+/** APPLICATION_KEY as defined in PowerAuth specification - a key identifying an application version.
  */
 @property (nonatomic, strong, nonnull) NSString	*appKey;
 
-/** APPLICATION_SECRET as defined in PowerAuth 2.0 specification - a secret associated with an application version.
+/** APPLICATION_SECRET as defined in PowerAuth specification - a secret associated with an application version.
  */
 @property (nonatomic, strong, nonnull) NSString	*appSecret;
 
-/** KEY_SERVER_MASTER_PUBLIC as defined in PowerAuth 2.0 specification - a master server public key.
+/** KEY_SERVER_MASTER_PUBLIC as defined in PowerAuth specification - a master server public key.
  */
 @property (nonatomic, strong, nonnull) NSString	*masterServerPublicKey;
 

--- a/proj-xcode/Classes/sdk/PowerAuthSDK+Private.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK+Private.h
@@ -23,13 +23,21 @@
 // Exposing several private interfaces
 @interface PowerAuthSDK (Private)
 
-/// Contains instance identifier
+/**
+ Contains instance identifier
+ */
 @property (nonatomic, strong, readonly) NSString * privateInstanceId;
 
-/// Returns key required for unlok the possesion factor.
+/**
+ Returns key required for unlok the possesion factor.
+ */
 - (NSData*) deviceRelatedKey;
 
-/// Low level signature calculation. This method doesn't check protocol upgrade.
+/**
+ Low level signature calculation. Unlike the high level interface, this method doesn't check
+ the protocol upgrade flag. This is useful for situations, where the flag is validated elsewhere, or
+ when the request can be signed during the pending protocol upgrade.
+ */
 - (PA2HTTPRequestDataSignature*) signHttpRequestData:(PA2HTTPRequestData*)requestData
 									  authentication:(PowerAuthAuthentication*)authentication
 											   error:(NSError**)error;

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.h
@@ -219,7 +219,7 @@
 @property (nonatomic, strong, nullable, readonly) NSDictionary<NSString*, NSObject*>* lastFetchedCustomObject;
 
 
-/** Remove current activation by calling a PowerAuth 2.0 Standard RESTful API endpoint '/pa/activation/remove'.
+/** Remove current activation by calling a PowerAuth Standard RESTful API endpoint '/pa/activation/remove'.
  
  @param authentication An authentication instance specifying what factors should be used to sign the request.
  @param callback A callback with activation removal result - in case of an error, an error instance is not 'nil'.
@@ -314,7 +314,7 @@
 - (BOOL) unsafeChangePasswordFrom:(nonnull NSString*)oldPassword
 							   to:(nonnull NSString*)newPassword;
 
-/** Change the password, validate old password by calling a PowerAuth 2.0 Standard RESTful API endpoint '/pa/vault/unlock'.
+/** Change the password, validate old password by calling a PowerAuth Standard RESTful API endpoint '/pa/vault/unlock'.
  
  @param oldPassword Old password, currently set to store the data.
  @param newPassword New password, to be set in case authentication with old password passes.
@@ -328,7 +328,7 @@
 
 /** Regenerate a biometry related factor key.
  
- This method calls PowerAuth 2.0 Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for original private key decryption.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for original private key decryption.
  
  @param password Password used for authentication during vault unlocking call.
  @param callback The callback method with the biometry key adding operation result.
@@ -359,7 +359,7 @@
 
 /** Generate an derived encryption key with given index.
  
- This method calls PowerAuth 2.0 Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for subsequent key derivation using given index.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for subsequent key derivation using given index.
  
  @param authentication Authentication used for vault unlocking call.
  @param index Index of the derived key using KDF.
@@ -372,7 +372,7 @@
 
 /** Sign given data with the original device private key (asymetric signature).
  
- This method calls PowerAuth 2.0 Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for private key decryption. Data is then signed using ECDSA algorithm with this key and can be validated on the server side.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key used for private key decryption. Data is then signed using ECDSA algorithm with this key and can be validated on the server side.
  
  @param authentication Authentication used for vault unlocking call.
  @param data Data to be signed with the private key.
@@ -385,7 +385,7 @@
 
 /** Validate a user password.
  
- This method calls PowerAuth 2.0 Standard RESTful API endpoint '/pa/vault/unlock' to validate the signature value.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to validate the signature value.
  
  @param password Password to be verified.
  @param callback The callback method with error associated with the password validation.

--- a/proj-xcode/Classes/sdk/PowerAuthToken.h
+++ b/proj-xcode/Classes/sdk/PowerAuthToken.h
@@ -73,7 +73,7 @@
 
 /**
  The PowerAuthTokenStoreTask is an abstract type for token store task. The object type
- returned from store may vary between store implementations.
+ returned from store may vary between the store implementations.
  */
 typedef id PowerAuthTokenStoreTask;
 

--- a/proj-xcode/Classes/system/PA2System.h
+++ b/proj-xcode/Classes/system/PA2System.h
@@ -16,7 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-/** Checks if the device is jailbroken.
+/**
+ Checks if the device is jailbroken.
  
  @return YES if the device is jailbroken, NO otherwise.
  */
@@ -24,13 +25,15 @@ extern BOOL pa_isJailbroken(void);
 
 @interface PA2System : NSObject
 
-/** Detects if the PowerAuth 2.0 is compiled with debug features.
+/**
+ Detects if the PowerAuth SDK is compiled with debug features.
  
  @return YES if library uses debug features, NO otherwise.
  */
 + (BOOL) isInDebug;
 
-/** Checks if the device is jailbroken.
+/**
+ Checks if the device is jailbroken.
  
  Please not that this method is exposed as an Objective-C method and as such, it can be very easily detected and bypassed.
  As a result, this method is very good for basic checks for example for educational purpose (to tell users that jailbreaking

--- a/proj-xcode/TestClasses/PA2CoreTestsWrapper.mm
+++ b/proj-xcode/TestClasses/PA2CoreTestsWrapper.mm
@@ -87,7 +87,7 @@ using namespace cc7;
  */
 - (void) testRunPA2Tests
 {
-	BOOL result = [self runTestWithFilter:"pa2" excluded:"" testName:"PowerAuth2.0"];
+	BOOL result = [self runTestWithFilter:"pa2" excluded:"" testName:"PowerAuth"];
 	XCTAssertTrue(result);
 }
 

--- a/src/PowerAuthTests/TestData/pa2/compute-derived-keys.json
+++ b/src/PowerAuthTests/TestData/pa2/compute-derived-keys.json
@@ -1,5 +1,5 @@
 {
-	"description": "For \"/pa/activation/prepare\", client needs to be able to derive standard PowerAuth 2.0 keys from master shared secret key (masterSecretKey) => (signaturePossessionKey, signatureKnowledgeKey, signatureBiometryKey, transportKey, vaultEncryptionKey).",
+	"description": "For \"/pa/activation/prepare\", client needs to be able to derive standard PowerAuth keys from master shared secret key (masterSecretKey) => (signaturePossessionKey, signatureKnowledgeKey, signatureBiometryKey, transportKey, vaultEncryptionKey).",
 	"data": [{
 		"input": {
 			"masterSecretKey": "H0eFgDSODwztB6kypY920A=="


### PR DESCRIPTION
The main purpose of this PR is to remove "2.0" protocol naming from the documentation comments. There's no issue attached to this. I've checked also Android sources, but that was OK, so most of changes goes to Core C++ classes and IOS ObjC. 