### PR TITLE
Documentation: Added guides for migration to 0.20 and 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ In order to connect to the [PowerAuth](https://www.wultra.com/product/powerauth-
 - [PowerAuth SDK for watchOS](./docs/PowerAuth-SDK-for-watchOS.md)
 - [PowerAuth SDK for Android Apps](./docs/PowerAuth-SDK-for-Android.md)
 
+## Migration guides
+
+If you need to upgrade PowerAuth Mobile SDK to a newer version, you can check following migration guides:
+
+- [Migration from version `0.20.x` to `1.0.0`](./docs/Migration-from-0.20-to-1.0.md)
+- [Migration from version `0.19.x` to `0.20.0`](./docs/Migration-from-0.19-to-0.20.md)
+
 ## License
 
 All sources are licensed using Apache 2.0 license, you can use them with no restriction. If you are using PowerAuth 2.0, please let us know. We will be happy to share and promote your project.

--- a/docs/Migration-from-0.19-to-0.20.md
+++ b/docs/Migration-from-0.19-to-0.20.md
@@ -1,0 +1,32 @@
+# Migration from 0.19.x to 0.20.x
+
+This guide contains instructions for migration from PowerAuth Mobile SDK version `0.19.x` to version `0.20.0`.
+
+## Introduction
+
+In PowerAuth Release `2018.12`, we have introduced a few cryprographic improvements in PowerAuth procotol, which unfortunately leads to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
+
+- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with both, "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues in this version of SDK.
+- PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
+
+Fortunately, we have achieved that those both versions are API compatible, as much as possible. That means that if you upgrade to `0.20.0` now, then you'll have less issues with migration to `1.0.0` once your server gets update to "V3" protocol. 
+
+## Android API changes
+
+- `PowerAuthAuthorizationHttpHeader` is now located at `io.getlime.security.powerauth.sdk` package. You need to update your imports by remove `.impl` part from import path.
+
+- `AsyncTask` is no longer returned from asynchronous SDK methods. We're using a custom `ICancelable` interface from `io.getlime.security.powerauth.networking.interfaces` package as a replacement.
+
+- Following constants from `PowerAuthErrorCodes` class are now deprecated (will be removed in `1.0`): 
+  - `PA2ErrorCodeAuthenticationFailed`
+  - `PA2ErrorCodeKeychain`
+  - `PA2ErrorCodeTouchIDNotAvailable` 
+  - `PA2ErrorCodeTouchIDCancel` deprecated and replaced with `PA2ErrorCodeBiometryCancel`
+
+## iOS API changes
+
+- All asycnhronous APIs now returns nullable `PA2OperationTask`. If `nil` is returned, then the asynchronous operation was not started properly. That may typically happen when you provide for example invalid parameters to the function. So, it's no longer required to check `task.isCancelled` to check whether the operation is properly started.
+
+- Following constants are now deprecated:
+  - `PA2ErrorCodeAuthenticationFailed` removed (unused)
+  - `PA2ErrorCodeKeychain` removed (unused)

--- a/docs/Migration-from-0.19-to-0.20.md
+++ b/docs/Migration-from-0.19-to-0.20.md
@@ -4,7 +4,7 @@ This guide contains instructions for migration from PowerAuth Mobile SDK version
 
 ## Introduction
 
-In PowerAuth Release `2018.12`, we have introduced a few cryprographic improvements in PowerAuth procotol, which unfortunately leads to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
+In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately leads to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
 
 - PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with both, "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues in this version of SDK.
 - PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
@@ -22,10 +22,39 @@ Fortunately, we have achieved that those both versions are API compatible, as mu
   - `PA2ErrorCodeKeychain`
   - `PA2ErrorCodeTouchIDNotAvailable` 
   - `PA2ErrorCodeTouchIDCancel` deprecated and replaced with `PA2ErrorCodeBiometryCancel`
+  
+- `ICommitActivationWithFingerprintListener` interface has a new callback method which has to be implemented in your application:
+  ```java
+  void onFingerprintDialogFailed(PowerAuthErrorException error) {
+      // The error happens in rare cases, like when you reset the activation during a wait for user's interaction with 
+      // that fingerprint dialog. That usually means a logic error in your application, so you should print that error
+      // and restart the activation process.
+  }
+  ```
+
+- `ICreateActivationListener` interface, in case of success, provides `CreateActivationResult` object, instead of separate parameters. For example:
+  ```java
+  ICancelable task = powerAuthSDK.createActivation("Juraj's test", activationCode, new ICreateActivationListener() {
+      @Override
+      public void onActivationCreateSucceed(CreateActivationResult result) {
+          // Get fingerprint & custom attributes
+          final String fingerprint = result.getActivationFingerprint();
+          final Map<String, Object> customAttributes = result.getCustomActivationAttributes();
+          // Continue with commit...
+      }
+
+      @Override
+      public void onActivationCreateFailed(Throwable t) {
+          // Error occurred, report it to the user
+          android.util.Log.d(TAG, "Create activation failed: " + t.getLocalizedMessage());
+      }
+  });
+  ```
+  
 
 ## iOS API changes
 
-- All asycnhronous APIs now returns nullable `PA2OperationTask`. If `nil` is returned, then the asynchronous operation was not started properly. That may typically happen when you provide for example invalid parameters to the function. So, it's no longer required to check `task.isCancelled` to check whether the operation is properly started.
+- All asynchronous APIs now returns nullable `PA2OperationTask`. If `nil` is returned, then the asynchronous operation was not started properly. That may typically happen when you provide for example invalid parameters to the function. So, it's no longer required to check `task.isCancelled` to check whether the operation is properly started.
 
 - Following constants are now deprecated:
   - `PA2ErrorCodeAuthenticationFailed` removed (unused)

--- a/docs/Migration-from-0.19-to-0.20.md
+++ b/docs/Migration-from-0.19-to-0.20.md
@@ -4,9 +4,9 @@ This guide contains instructions for migration from PowerAuth Mobile SDK version
 
 ## Introduction
 
-In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately leads to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
+In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
 
-- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with both, "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues in this version of SDK.
+- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
 - PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
 
 Fortunately, we have achieved that those both versions are API compatible, as much as possible. That means that if you upgrade to `0.20.0` now, then you'll have less issues with migration to `1.0.0` once your server gets update to "V3" protocol. 

--- a/docs/Migration-from-0.19-to-0.20.md
+++ b/docs/Migration-from-0.19-to-0.20.md
@@ -6,8 +6,8 @@ This guide contains instructions for migration from PowerAuth Mobile SDK version
 
 In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
 
-- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
-- PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
+- PowerAuth Mobile SDK `0.20.x` (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
+- PowerAuth Mobile SDK `1.0.x` is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
 
 Fortunately, we have achieved that those both versions are API compatible, as much as possible. That means that if you upgrade to `0.20.0` now, then you'll have less issues with migration to `1.0.0` once your server gets update to "V3" protocol. 
 

--- a/docs/Migration-from-0.20-to-1.0.md
+++ b/docs/Migration-from-0.20-to-1.0.md
@@ -6,8 +6,8 @@ This guide contains instructions for migration from PowerAuth Mobile SDK version
 
 In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
 
-- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
-- PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
+- PowerAuth Mobile SDK `0.20.x` (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
+- PowerAuth Mobile SDK `1.0.x` is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
 
 Fortunately, we have achieved that those both versions are API compatible, as much as possible. So, if you already migrated to version `0.20.0`, then the migration to `1.0.0` should be a quite easy now. Check [Migration from 0.19.0 to 0.20.0](./Migration-from-0.19-to-0.20.md) for more details.
 

--- a/docs/Migration-from-0.20-to-1.0.md
+++ b/docs/Migration-from-0.20-to-1.0.md
@@ -4,7 +4,7 @@ This guide contains instructions for migration from PowerAuth Mobile SDK version
 
 ## Introduction
 
-In PowerAuth Release `2018.12`, we have introduced a few cryprographic improvements in PowerAuth procotol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
+In PowerAuth Release `2018.12`, we have introduced a few cryptographic improvements in PowerAuth protocol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
 
 - PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
 - PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
@@ -23,16 +23,16 @@ Fortunately, we have achieved that those both versions are API compatible, as mu
   - `PA2ErrorCodeTouchIDNotAvailable` removed (unused) 
   - `PA2ErrorCodeTouchIDCancel` is now replaced with `PA2ErrorCodeBiometryCancel`
 
-- We have removed all interfaces related to our "V2" E2E encryption (e.g. classes like `Encryptor`, `PA2EncryptorFactory`...). You can now use following intefaces as a replacement:
+- We have removed all interfaces related to our "V2" E2E encryption (e.g. classes like `Encryptor`, `PA2EncryptorFactory`...). You can now use following interfaces as a replacement:
   - `EciesEncryptor` as a common object for custom request encryption and decryption. You can acquire a right encryptor object from `PowerAuthSDK` instance. Check [SDK documentation for details](./PowerAuth-SDK-for-Android.md#end-to-end-encryption).
   - `EciesCryptogram` is now a common representation for encrypted request and response.
 
-- We have changed inteface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
+- We have changed interface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
   - Use new `PowerAuthSDK.createCustomActivation(...)` method
 
 - We have added a several annotations to our API, that may lead to several warnings, if you mis-use our interfaces:
   - Usage of integer constant from `PowerAuthErrorCodes`, is now marked with with `@PowerAuthErrorCodes` annotation
-  - Usage of integer constatn from `ErrorCode` (low level APIs), is now marked with `@ErrorCode` annotation
+  - Usage of integer constant from `ErrorCode` (low level APIs), is now marked with `@ErrorCode` annotation
   - All callbacks from `PowerAuthSDK` class are now returned to the main thread (`@MainThread` annotation)
   - Added nullability attributes to more interfaces.
 
@@ -53,7 +53,7 @@ Fortunately, we have achieved that those both versions are API compatible, as mu
   - `PA2ECIESEncryptor` as a common object for custom request encryption and decryption. You can acquire a right encryptor object from `PowerAuthSDK` instance. Check [SDK documentation for details](./PowerAuth-SDK-for-iOS.md#end-to-end-encryption).
   - `PA2ECIESCryptogram` is now a common representation for encrypted request and response.
 
-- We have changed inteface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
+- We have changed interface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
   - Use a new method:
     ```objc
     - (nullable id<PA2OperationTask>) createActivationWithName:(nullable NSString*)name
@@ -62,7 +62,7 @@ Fortunately, we have achieved that those both versions are API compatible, as mu
                                                       callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
     ```
 
-- `PA2OperationTask` is now a protocol instead of class. This change should not have an implications to your code, unless you accessed properties from previous object implementation. 
+- `PA2OperationTask` is now a protocol instead of class. This change should not have an implications to your code, unless you accessed properties from previous object implementation.
 
 - You should handle following new error constants in your application:
   - `PA2ErrorCodeProtocolUpgrade` - unrecoverable protocol upgrade error

--- a/docs/Migration-from-0.20-to-1.0.md
+++ b/docs/Migration-from-0.20-to-1.0.md
@@ -1,0 +1,70 @@
+# Migration from 0.20.x to 1.0.0
+
+This guide contains instructions for migration from PowerAuth Mobile SDK version 0.20.x to version 1.0.0.
+
+## Introduction
+
+In PowerAuth Release `2018.12`, we have introduced a few cryprographic improvements in PowerAuth procotol, which unfortunately led to few API breaking changes. We're calling all this changes in our documentation as "Crypto 3.0", or "PowerAuth protocol V3". Similarly, the old, legacy crypto, is now called as "PowerAuth protocol V2". Unfortunately, all this means that "V3" clients, cannot work with "V2" servers. So, we need to keep, for a limited time, two separate versions of SDK:
+
+- PowerAuth Mobile SDK 0.20.x (in git branch `release/0.20.x`) is now a legacy version of SDK, based on PowerAuth protocol V2 and can cooperate with "V2" and "V3" servers. We will provide only a limited support for this branch of SDK. That means that we will fix only a critical or a security issues.
+- PowerAuth Mobile SDK 1.0.x is now a main, fully supported branch of SDK, which can cooperate with "V3" servers only.
+
+Fortunately, we have achieved that those both versions are API compatible, as much as possible. So, if you already migrated to version `0.20.0`, then the migration to `1.0.0` should be a quite easy now. Check [Migration from 0.19.0 to 0.20.0](./Migration-from-0.19-to-0.20.md) for more details.
+
+## Android
+
+### API changes
+
+- Minimum API level is now 16
+
+- Removed following constants from `PowerAuthErrorCodes` class: 
+  - `PA2ErrorCodeAuthenticationFailed` removed (unused)
+  - `PA2ErrorCodeKeychain` removed (unused)
+  - `PA2ErrorCodeTouchIDNotAvailable` removed (unused) 
+  - `PA2ErrorCodeTouchIDCancel` is now replaced with `PA2ErrorCodeBiometryCancel`
+
+- We have removed all interfaces related to our "V2" E2E encryption (e.g. classes like `Encryptor`, `PA2EncryptorFactory`...). You can now use following intefaces as a replacement:
+  - `EciesEncryptor` as a common object for custom request encryption and decryption. You can acquire a right encryptor object from `PowerAuthSDK` instance. Check [SDK documentation for details](./PowerAuth-SDK-for-Android.md#end-to-end-encryption).
+  - `EciesCryptogram` is now a common representation for encrypted request and response.
+
+- We have changed inteface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
+  - Use new `PowerAuthSDK.createCustomActivation(...)` method
+
+- We have added a several annotations to our API, that may lead to several warnings, if you mis-use our interfaces:
+  - Usage of integer constant from `PowerAuthErrorCodes`, is now marked with with `@PowerAuthErrorCodes` annotation
+  - Usage of integer constatn from `ErrorCode` (low level APIs), is now marked with `@ErrorCode` annotation
+  - All callbacks from `PowerAuthSDK` class are now returned to the main thread (`@MainThread` annotation)
+  - Added nullability attributes to more interfaces.
+
+- You should handle following new error constants in your application:
+  - `PA2ErrorCodeProtocolUpgrade` - unrecoverable protocol upgrade error
+  - `PA2ErrorCodePendingProtocolUpgrade` - operation is temporarily unavailable due to protocol upgrade.
+  - Check [Error handling](./PowerAuth-SDK-for-Android.md#error-handling) for more details
+
+## iOS
+
+### API changes
+
+- Removed following unused constants:
+  - `PA2ErrorCodeAuthenticationFailed` removed (unused)
+  - `PA2ErrorCodeKeychain` removed (unused)
+
+- We have removed all interfaces related to our "V2" E2E encryption (e.g. classes like `PA2EncryptorFactory`). You can now use following interfaces as a replacement:
+  - `PA2ECIESEncryptor` as a common object for custom request encryption and decryption. You can acquire a right encryptor object from `PowerAuthSDK` instance. Check [SDK documentation for details](./PowerAuth-SDK-for-iOS.md#end-to-end-encryption).
+  - `PA2ECIESCryptogram` is now a common representation for encrypted request and response.
+
+- We have changed inteface for custom activations, which is now much simpler. The custom activation is now fully supported in SDK, so you don't need to provide a custom URL, or other parameters.
+  - Use a new method:
+    ```objc
+    - (nullable id<PA2OperationTask>) createActivationWithName:(nullable NSString*)name
+                                            identityAttributes:(nonnull NSDictionary<NSString*,NSString*>*)identityAttributes
+                                                        extras:(nullable NSString*)extras
+                                                      callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
+    ```
+
+- `PA2OperationTask` is now a protocol instead of class. This change should not have an implications to your code, unless you accessed properties from previous object implementation. 
+
+- You should handle following new error constants in your application:
+  - `PA2ErrorCodeProtocolUpgrade` - unrecoverable protocol upgrade error
+  - `PA2ErrorCodePendingProtocolUpgrade` - operation is temporarily unavailable due to protocol upgrade.
+  - Check [Error handling](./PowerAuth-SDK-for-iOS.md#error-handling) for more details

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -9,6 +9,13 @@ In order to connect to the [PowerAuth](https://www.wultra.com/product/powerauth-
 - [PowerAuth SDK for watchOS](./PowerAuth-SDK-for-watchOS.md)
 - [PowerAuth SDK for Android Apps](./PowerAuth-SDK-for-Android.md)
 
+## Migration guides
+
+If you need to upgrade PowerAuth Mobile SDK to a newer version, you can check following migration guides:
+
+- [Migration from version `0.20.x` to `1.0.0`](./Migration-from-0.20-to-1.0.md)
+- [Migration from version `0.19.x` to `0.20.0`](./Migration-from-0.19-to-0.20.md)
+
 ## License
 
 All sources are licensed using Apache 2.0 license, you can use them with no restriction. If you are using PowerAuth 2.0, please let us know. We will be happy to share and promote your project.

--- a/docs/Supported-Versions.md
+++ b/docs/Supported-Versions.md
@@ -4,4 +4,4 @@ We currently support following versions of mobile OS:
 
 - iOS 8.0 _(Touch ID since iOS 9)_
 - watchOS 2.0
-- Android 4.0.3 _(Fingerprint authentication since Android 6.0)_
+- Android 4.1 _(Fingerprint authentication since Android 6.0)_


### PR DESCRIPTION
This PR brings a migration guides describing how to migrate from older to newer versions of SDK

Close #203 