### PR TITLE
Issue/208 documentation update

### DIFF
--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1205,8 +1205,4 @@ final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConf
             .build();
 ```
 
-We don't recommend you to implement `HttpRequestInterceptor` interface on your own. The interface allows you to tweak the requests 
-created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor,
-try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface 
-may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability
-of interface itself.
+We don't recommend you to implement `HttpRequestInterceptor` interface on your own. The interface allows you to tweak the requests created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor, try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability of interface itself.

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -23,7 +23,11 @@
 - [Token Based Authentication](#token-based-authentication)
 - [Common SDK Tasks](#common-sdk-tasks)
 - [Additional Features](#additional-features)
-
+  - [Password Strength Indicator](#password-strength-indicator)
+  - [Debug Build Detection](#debug-build-detection)
+  - [Request Interceptors](#request-interceptors)
+  
+    
 ## Installation
 
 To get PowerAuth SDK for Android up and running in your app, add following dependency in your `gradle.build` file:
@@ -974,7 +978,7 @@ powerAuthSDK.initializeWithConfiguration(context, configuration, clientConfigura
 
 ## Additional Features
 
-PowerAuth SDK for Android contains multiple additional security features that are useful for mobile apps.
+PowerAuth SDK for Android contains multiple additional features that are useful for mobile apps.
 
 ### Password Strength Indicator
 
@@ -988,3 +992,38 @@ PasswordStrength strength = PasswordUtil.evaluateStrength("1234", PasswordType.P
 Passwords that are `INVALID` should block the progress. You should translate `WEAK` passwords to UI warnings (not blocking progress), `NORMAL` passwords to OK state, and `STRONG` passwords to rewarding UI message (so that we appreciate user selected strong password, without pushing the user to selecting strong password too hard).
 
 Of course, you may apply any additional measures for the password validity and strength on top of the logics we provide.
+
+### Debug build detection
+
+It is sometimes useful to switch PowerAuth SDK to a DEBUG build configuration, to get more logs from the library. The DEBUG build is usually helpful during the application development, but on other side, it's highly unwanted in production applications. For this purpose, the `PowerAuthSDK.hasDebugFeatures()` method provides an information, whether the PowerAuth JNI library was compiled in DEBUG configuration. It is a good practice to check this flag and crash the process when the production application is linked against the DEBUG PowerAuth:
+
+```java
+if (!BuildConfig.DEBUG) {
+    // You can also check your production build configuration
+    if (powerAuthSDK.hasDebugFeatures()) {
+        throw new RuntimeException("Production app with DEBUG PowerAuth");
+    }
+}
+```
+
+### Request Interceptors
+
+The `PowerAuthClientConfiguration` can contain a multiple request interceptor objects, allowing you to adjust all HTTP requests created by SDK, before execution. Currently, you can use following two classes:
+
+- `BasicHttpAuthenticationRequestInterceptor` to add basic HTTP authentication header to all requests
+- `CustomHeaderRequestInterceptor` to add a custom HTTP header to all requests
+
+For example: 
+
+```java
+final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConfiguration.Builder()
+            .requestInterceptor(new BasicHttpAuthenticationRequestInterceptor("gateway-user", "gateway-password"))
+            .requestInterceptor(new CustomHeaderRequestInterceptor("X-CustomHeader", "123456"))
+            .build();
+```
+
+We don't recommend you to implement `HttpRequestInterceptor` interface on your own. The interface allows you to tweak the requests 
+created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor,
+try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface 
+may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability
+of interface itself.

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -142,6 +142,8 @@ powerAuthSDK.createActivation(deviceName, activationCode, new ICreateActivationL
 });
 ```
 
+If the received activation result also contains a recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
+
 ### Activation via Custom Credentials
 
 You may also create an activation using any custom login data - it can be anything that server can use to obtain user ID to associate with a new activation. Since the credentials are custom, the server's implementation must be able to process such request. Unlike the previous versions of SDK, the custom activation no longer requires a custom activation endpoint.
@@ -882,11 +884,29 @@ powerAuthSDK.fetchEncryptionKey(context, authentication, index, new IFetchEncryp
 
 ## Recovery Codes
 
-If PowerAuth Server is configured to support [Recovery Codes](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md), then your application can use several methods related to recovery codes.
+The recovery codes allows your users to recovery their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
+
+To recovery an activation, the user has to re-type two separate values:
+
+1. Recovery Code itself, which is very similar to an activation code. So you can detect typing errors before you submit such code to the server. 
+1. PUK, which is an additional numeric value and acts as an one time password in the scheme.
+
+PowerAuth currently supports two basic types of recovery codes:
+
+1. Recovery Code bound to a previous PowerAuth activation.
+  - This type of code can be obtained only in an already activated application.
+  - This type of code has only one PUK available, so only one recovery operation is possible.
+  - The activation associated with the code is removed once the recovery operation succeeds.
+  
+2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
+  - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+  - User has to keep that postcard at safe and secure place and mark already used PUKs.
+
+The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 
 ### Getting Recovery Data
 
-To check existence of recovery data and get that information, use following code:
+If the recovery data was received during the activation process, then you can later display that information to the user. To check existence of recovery data and get that information, use following code:
 
 ```java
 if (!powerAuthSDK.hasActivationRecoveryData()) {
@@ -915,7 +935,7 @@ powerAuthSDK.getActivationRecoveryData(context, authentication, new IGetRecovery
 });
 ```
 
-The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
+WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
 - You should never store `recoveryCode` or `puk` on the device
 - You should never print that values to debug log
@@ -933,7 +953,7 @@ You should inform user that:
 
 ### Confirm Recovery Postcard
 
-The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its delivery. To confirm such recovery code, use following code:
+The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
 
 ```java
 // 2FA signature with possession factor is required

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -901,6 +901,7 @@ PowerAuth currently supports two basic types of recovery codes:
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
    - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
    - User has to keep that postcard at safe and secure place and mark already used PUKs.
+   - The code delivery must be confirmed by the user, before it can be used for a recovery operation.
 
 The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 
@@ -938,9 +939,9 @@ powerAuthSDK.getActivationRecoveryData(context, authentication, new IGetRecovery
 WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
 - You should never store `recoveryCode` or `puk` on the device
-- You should never print that values to debug log
+- You should never print that values to the debug log
 - You should never send that values over the network
-- You should never copy that values to clipboard
+- You should never copy that values to the clipboard
 - Do not cache that values in RAM. 
 - Your UI logic should require PIN every time the vales are going to display on the screen.
 - Your application should not allow taking screenshots when values are displayed on the screen.
@@ -980,6 +981,7 @@ powerAuthSDK.confirmRecoveryCode(context, authentication, recoveryCode, new ICon
 });
 ```
 
+The `alreadyConfirmed` boolean indicates that code was already confirmed in past. You can choose a different "success" screen, describing that user has already confirmed such code. Also note that codes bound to the activations are already confirmed.
 
 ## Token Based Authentication
 

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -142,7 +142,7 @@ powerAuthSDK.createActivation(deviceName, activationCode, new ICreateActivationL
 });
 ```
 
-If the received activation result also contains a recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
+If the received activation result also contains recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
 
 ### Activation via Custom Credentials
 
@@ -332,7 +332,7 @@ boolean isValid   = OtpUtil.validateRecoveryPuk("0123456789");
 
 #### Auto-correcting typed characters
 
-You can implement auto-correcting of typed characters with using `OtpUtil.validateAndCorrectTypedCharacter()` function in screens, where user suppose to enter an activation, or recovery code. This technique is possible due to fact, that Base32 is specially constructed that doesn't contain visually confusing characters. For example, `1` (number one) and `I` (capital I) are confusing, so only `I` is allowed. The benefit is that provided function can correct typed `1` and translate it to `I`. 
+You can implement auto-correcting of typed characters with using `OtpUtil.validateAndCorrectTypedCharacter()` function in screens, where user is suppose to enter an activation or recovery code. This technique is possible due to fact, that Base32 is specially constructed that doesn't contain visually confusing characters. For example, `1` (number one) and `I` (capital I) are confusing, so only `I` is allowed. The benefit is that provided function can correct typed `1` and translate it to `I`. 
 
 Here's an example how to iterate over the string and validate it character by character:
 
@@ -884,9 +884,9 @@ powerAuthSDK.fetchEncryptionKey(context, authentication, index, new IFetchEncryp
 
 ## Recovery Codes
 
-The recovery codes allows your users to recovery their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
+The recovery codes allows your users to recover their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
 
-To recovery an activation, the user has to re-type two separate values:
+To recover an activation, the user has to re-type two separate values:
 
 1. Recovery Code itself, which is very similar to an activation code. So you can detect typing errors before you submit such code to the server. 
 1. PUK, which is an additional numeric value and acts as an one time password in the scheme.
@@ -899,7 +899,7 @@ PowerAuth currently supports two basic types of recovery codes:
    - The activation associated with the code is removed once the recovery operation succeeds.
   
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
-   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times.
    - User has to keep that postcard at safe and secure place and mark already used PUKs.
    - The code delivery must be confirmed by the user, before it can be used for a recovery operation.
 
@@ -938,23 +938,23 @@ powerAuthSDK.getActivationRecoveryData(context, authentication, new IGetRecovery
 
 WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
-- You should never store `recoveryCode` or `puk` on the device
-- You should never print that values to the debug log
-- You should never send that values over the network
-- You should never copy that values to the clipboard
-- Do not cache that values in RAM. 
+- You should never store `recoveryCode` or `puk` on the device.
+- You should never print that values to the debug log.
+- You should never send that values over the network.
+- You should never copy that values to the clipboard.
+- Do not cache that values in RAM.
 - Your UI logic should require PIN every time the vales are going to display on the screen.
 - Your application should not allow taking screenshots when values are displayed on the screen.
 
 You should inform user that:
 
-- Making screenshot when values are displayed on the screen is dangerous (in case that you did not disable taking screenshots)
+- Making screenshot when values are displayed on the screen is dangerous (in case that you did not disable taking screenshots).
 - User should write down that values on paper and keep it as much safe as possible for future use.
 
 
 ### Confirm Recovery Postcard
 
-The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
+The recovery postcard can contain the recovery code and multiple PUK values on one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
 
 ```java
 // 2FA signature with possession factor is required

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -360,7 +360,7 @@ authentication.usePassword = "1234";
 authentication.useBiometry = null;
 
 // Sign POST call with provided data made to URI with custom identifier "/payment/create"
-PowerAuthAuthorizationHttpHeader header = this.requestSignatureWithAuthentication(context, authentication, "POST", "/payment/create", requestBodyBytes);
+PowerAuthAuthorizationHttpHeader header = powerAuthSDK.requestSignatureWithAuthentication(context, authentication, "POST", "/payment/create", requestBodyBytes);
 if (header.isValid()) {
     String httpHeaderKey = header.getKey();
     String httpHeaderValue = header.getValue();
@@ -383,7 +383,7 @@ Map<String, String> params = new HashMap<>();
 params.put("param1", "value1");
 params.put("param2", "value2");
 
-PowerAuthAuthorizationHttpHeader header = this.requestGetSignatureWithAuthentication(context, authentication, "/payment/create", params);
+PowerAuthAuthorizationHttpHeader header = powerAuthSDK.requestGetSignatureWithAuthentication(context, authentication, "/payment/create", params);
 if (header.isValid()) {
     String httpHeaderKey = header.getKey();
     String httpHeaderValue = header.getValue();
@@ -410,6 +410,23 @@ builder.header(header.getKey(), header.getValue());
 
 // Build the request, send it and process response...
 // ...
+```
+
+#### Request Synchronization
+
+It is recommended that your application executes only one signed request at the time. The reason for that is that our signature scheme is using a counter as a representation of logical time. In other words, the order of request validation on the server is very important. If you issue more that one signed request at the same time, then the order is not guaranteed and therefore one from the requests may fail. On top of that, Mobile SDK itself is using this type of signatures for its own purposes. For example, if you ask for token, then the SDK is using signed request to obtain the token's data. To deal with this problem, Mobile SDK is providing a custom serial `Executor`, which can be used for signed requests execution: 
+
+```java
+final Executor serialExecutor = powerAuthSDK.getSerialExecutor();
+serialExecutor.execute(new Runnable() {
+    @Override
+    public void run() {
+        // Recommended practice:
+        // 1. You have to calculate PowerAuth signature here.
+        // 2. In case that you start yet another asynchronous operation from run(),
+        //    then you have to wait for that operation's execution.
+    }
+});
 ```
 
 ### Asymmetric Private Key Signature

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -894,13 +894,13 @@ To recovery an activation, the user has to re-type two separate values:
 PowerAuth currently supports two basic types of recovery codes:
 
 1. Recovery Code bound to a previous PowerAuth activation.
-  - This type of code can be obtained only in an already activated application.
-  - This type of code has only one PUK available, so only one recovery operation is possible.
-  - The activation associated with the code is removed once the recovery operation succeeds.
+   - This type of code can be obtained only in an already activated application.
+   - This type of code has only one PUK available, so only one recovery operation is possible.
+   - The activation associated with the code is removed once the recovery operation succeeds.
   
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
-  - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
-  - User has to keep that postcard at safe and secure place and mark already used PUKs.
+   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+   - User has to keep that postcard at safe and secure place and mark already used PUKs.
 
 The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1423,9 +1423,5 @@ let clientConfig = PA2ClientConfiguration()
 clientConfig.requestInterceptors = [ basicAuth, customHeader ]
 ```
 
-We don't recommend you to implement `PA2HttpRequestInterceptor` protocol on your own. The interface allows you to tweak the requests 
-created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor,
-try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface 
-may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability
-of interface itself.
+We don't recommend you to implement `PA2HttpRequestInterceptor` protocol on your own. The interface allows you to tweak the requests created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor, try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability of interface itself.
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -202,7 +202,7 @@ PowerAuthSDK.sharedInstance().createActivation(withName: deviceName, activationC
 }
 ```
 
-If the received activation result also contains a recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
+If the received activation result also contains recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
 
 ### Activation via Custom Credentials
 
@@ -355,7 +355,7 @@ let isValid   = PA2OtpUtil.validateRecoveryPuk("0123456789")
 
 #### Auto-correcting typed characters
 
-You can implement auto-correcting of typed characters with using `PA2OtpUtil.validateAndCorrectTypedCharacter()` function in screens, where user suppose to enter an activation, or recovery code. This technique is possible due to fact, that Base32 is specially constructed that doesn't contain visually confusing characters. For example, `1` (number one) and `I` (capital I) are confusing, so only `I` is allowed. The benefit is that provided function can correct typed `1` and translate it to `I`. 
+You can implement auto-correcting of typed characters with using `PA2OtpUtil.validateAndCorrectTypedCharacter()` function in screens, where user is suppose to enter an activation or recovery code. This technique is possible due to fact, that Base32 is specially constructed that doesn't contain visually confusing characters. For example, `1` (number one) and `I` (capital I) are confusing, so only `I` is allowed. The benefit is that provided function can correct typed `1` and translate it to `I`. 
 
 Here's an example how to iterate over the string and validate it character by character:
 
@@ -860,9 +860,9 @@ PowerAuthSDK.sharedInstance().fetchEncryptionKey(auth, index: index) { (encrypti
 
 ## Recovery Codes
 
-The recovery codes allows your users to recovery their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
+The recovery codes allows your users to recover their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
 
-To recovery an activation, the user has to re-type two separate values:
+To recover an activation, the user has to re-type two separate values:
 
 1. Recovery Code itself, which is very similar to an activation code. So you can detect typing errors before you submit such code to the server. 
 1. PUK, which is an additional numeric value and acts as an one time password in the scheme.
@@ -875,7 +875,7 @@ PowerAuth currently supports two basic types of recovery codes:
    - The activation associated with the code is removed once the recovery operation succeeds.
   
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
-   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times.
    - User has to keep that postcard at safe and secure place and mark already used PUKs.
    - The code delivery must be confirmed by the user, before it can be used for a recovery operation.
 
@@ -908,11 +908,11 @@ powerAuthSdk.activationRecoveryData(auth) { recoveryData, error in
 
 WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
-- You should never store `recoveryCode` or `puk` on the device
-- You should never print that values to the debug log
-- You should never send that values over the network
-- You should never copy that values to the clipboard
-- Do not cache that values in RAM. 
+- You should never store `recoveryCode` or `puk` on the device.
+- You should never print that values to the debug log.
+- You should never send that values over the network.
+- You should never copy that values to the clipboard.
+- Do not cache that values in RAM.
 - Your UI logic should require PIN every time the vales are going to display on the screen.
 - You should catch a takin screenshot event when values are displayed on the screen and warn user, that such practice is not recommended.
 
@@ -924,7 +924,7 @@ You should inform user that:
 
 ### Confirm Recovery Postcard
 
-The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
+The recovery postcard can contain the recovery code and multiple PUK values on one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
 
 ```swift
 // 2FA signature with possession factor is required

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1251,8 +1251,8 @@ The `PA2ClientConfiguration` can contain a multiple request interceptor objects,
 For example: 
 
 ```swift
-let basicAuth = PA2BasicHttpAuthenticationRequestInterceptor(username: "gateway-use", password: "gateway-password")
-let customHeader = PA2CustomHeaderRequestInterceptor(headerKey: "gateway-user", value: "gateway-password")
+let basicAuth = PA2BasicHttpAuthenticationRequestInterceptor(username: "gateway-user", password: "gateway-password")
+let customHeader = PA2CustomHeaderRequestInterceptor(headerKey: "X-CustomHeader", value: "123456")
 let clientConfig = PA2ClientConfiguration()
 clientConfig.requestInterceptors = [ basicAuth, customHeader ]
 ```

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -35,6 +35,10 @@
    - [Removing Token from Watch](#removing-token-from-watch)
 - [Common SDK Tasks](#common-sdk-tasks)
 - [Additional Features](#additional-features)
+   - [Root Detection](#root-detection)
+   - [Password Strength Indicator](#password-strength-indicator)
+   - [Debug Build Detection](#debug-build-detection)
+   - [Request Interceptors](#request-interceptors)   
 
 Related documents:
 
@@ -1188,7 +1192,7 @@ PA2ClientConfiguration.sharedInstance().sslValidationStrategy = PA2ClientSslNoVa
 
 ## Additional Features
 
-PowerAuth SDK for iOS contains multiple additional security features that are useful for mobile apps.
+PowerAuth SDK for iOS contains multiple additional features that are useful for mobile apps.
 
 ### Root Detection
 
@@ -1236,3 +1240,26 @@ The DEBUG build is usually helpful during the application development, but on ot
     }
 #endif
 ```
+
+### Request Interceptors
+
+The `PA2ClientConfiguration` can contain a multiple request interceptor objects, allowing you to adjust all HTTP requests created by SDK, before execution. Currently, you can use following two classes:
+
+- `PA2BasicHttpAuthenticationRequestInterceptor` to add basic HTTP authentication header to all requests
+- `PA2CustomHeaderRequestInterceptor` to add a custom HTTP header to all requests
+
+For example: 
+
+```swift
+let basicAuth = PA2BasicHttpAuthenticationRequestInterceptor(username: "gateway-use", password: "gateway-password")
+let customHeader = PA2CustomHeaderRequestInterceptor(headerKey: "gateway-user", value: "gateway-password")
+let clientConfig = PA2ClientConfiguration()
+clientConfig.requestInterceptors = [ basicAuth, customHeader ]
+```
+
+We don't recommend you to implement `PA2HttpRequestInterceptor` protocol on your own. The interface allows you to tweak the requests 
+created in the `PowerAuthSDK`, but also gives you an opportunity to break the things. So, rather than create your own interceptor,
+try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also keep in mind, that the interface 
+may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability
+of interface itself.
+

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -877,6 +877,7 @@ PowerAuth currently supports two basic types of recovery codes:
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
    - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
    - User has to keep that postcard at safe and secure place and mark already used PUKs.
+   - The code delivery must be confirmed by the user, before it can be used for a recovery operation.
 
 The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 
@@ -908,9 +909,9 @@ powerAuthSdk.activationRecoveryData(auth) { recoveryData, error in
 WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
 - You should never store `recoveryCode` or `puk` on the device
-- You should never print that values to debug log
+- You should never print that values to the debug log
 - You should never send that values over the network
-- You should never copy that values to clipboard
+- You should never copy that values to the clipboard
 - Do not cache that values in RAM. 
 - Your UI logic should require PIN every time the vales are going to display on the screen.
 - You should catch a takin screenshot event when values are displayed on the screen and warn user, that such practice is not recommended.
@@ -943,6 +944,7 @@ PowerAuthSDK.sharedInstance().confirmRecoveryCode(recoveryCode, authentication: 
 }
 ```
 
+The `alreadyConfirmed` boolean indicates that code was already confirmed in past. You can choose a different "success" screen, describing that user has already confirmed such code. Also note that codes bound to the activations are already confirmed.
 
 ## Token Based Authentication
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -870,13 +870,13 @@ To recovery an activation, the user has to re-type two separate values:
 PowerAuth currently supports two basic types of recovery codes:
 
 1. Recovery Code bound to a previous PowerAuth activation.
-  - This type of code can be obtained only in an already activated application.
-  - This type of code has only one PUK available, so only one recovery operation is possible.
-  - The activation associated with the code is removed once the recovery operation succeeds.
+   - This type of code can be obtained only in an already activated application.
+   - This type of code has only one PUK available, so only one recovery operation is possible.
+   - The activation associated with the code is removed once the recovery operation succeeds.
   
 2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
-  - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
-  - User has to keep that postcard at safe and secure place and mark already used PUKs.
+   - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+   - User has to keep that postcard at safe and secure place and mark already used PUKs.
 
 The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -202,6 +202,8 @@ PowerAuthSDK.sharedInstance().createActivation(withName: deviceName, activationC
 }
 ```
 
+If the received activation result also contains a recovery data, then you should display that values to the user. To do that, please read [Getting Recovery Data](#getting-recovery-data) section of this document, which describes how to treat that sensitive information. This is relevant for all types of activation you use.
+
 ### Activation via Custom Credentials
 
 You may also create an activation using any custom login data - it can be anything that server can use to obtain user ID to associate with a new activation. Since the credentials are custom, the server's implementation must be able to process such request. Unlike the previous versions of SDK, the custom activation no longer requires a custom activation endpoint.
@@ -858,11 +860,29 @@ PowerAuthSDK.sharedInstance().fetchEncryptionKey(auth, index: index) { (encrypti
 
 ## Recovery Codes
 
-If PowerAuth Server is configured to support [Recovery Codes](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md), then your application can use several methods related to recovery codes.
+The recovery codes allows your users to recovery their activation in case that mobile device is lost or stolen. Before you start, please read [Activation Recovery](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) document, available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
+
+To recovery an activation, the user has to re-type two separate values:
+
+1. Recovery Code itself, which is very similar to an activation code. So you can detect typing errors before you submit such code to the server. 
+1. PUK, which is an additional numeric value and acts as an one time password in the scheme.
+
+PowerAuth currently supports two basic types of recovery codes:
+
+1. Recovery Code bound to a previous PowerAuth activation.
+  - This type of code can be obtained only in an already activated application.
+  - This type of code has only one PUK available, so only one recovery operation is possible.
+  - The activation associated with the code is removed once the recovery operation succeeds.
+  
+2. Recovery Code delivered via OOB channel, typically in form of securely printed postcard, delivered by a post service.
+  - This type of code has typically more than one PUK associated with the code, so it can be used for multiple times
+  - User has to keep that postcard at safe and secure place and mark already used PUKs.
+
+The feature is not automatically available, but must be enabled and configured on PowerAuth Server. If it's so, then your mobile application can use several methods related to this feature.
 
 ### Getting Recovery Data
 
-To check existence of recovery data and get that information, use following code:
+If the recovery data was received during the activation process, then you can later display that information to the user. To check existence of recovery data and get that information, use following code:
 
 ```swift
 let powerAuthSdk = PowerAuthSDK.sharedInstance() 
@@ -885,7 +905,7 @@ powerAuthSdk.activationRecoveryData(auth) { recoveryData, error in
 }
 ```
 
-The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
+WARNING: The obtained information is very sensitive, so you should be very careful how your application manipulate with that received values:
 
 - You should never store `recoveryCode` or `puk` on the device
 - You should never print that values to debug log
@@ -903,7 +923,7 @@ You should inform user that:
 
 ### Confirm Recovery Postcard
 
-The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its delivery. To confirm such recovery code, use following code:
+The recovery postcard can contain the recovery code and multiple PUK values at one printed card. Due to security reasons, this kind of recovery code cannot be used for the recovery operation before user confirms its physical delivery. To confirm such recovery code, use following code:
 
 ```swift
 // 2FA signature with possession factor is required


### PR DESCRIPTION
Documentation update

- Added missing documentation
   - For `PA2OtpUtil` / `OtpUtil` class
   - For request interceptors
   - For synchronizing signed HTTP requests
- Added documentation for a new Recovery Code feature

The feature can be reviewed on per-commit basis. Dead link to `powerauth-crypto` will be available once I submit a similar documentation update change to that repo.