### PR TITLE
Android: Fixed #220: Dynamic .so lib now has GNU_HASH & HASH sections

### DIFF
--- a/src/Android.mk
+++ b/src/Android.mk
@@ -124,9 +124,9 @@ LOCAL_CPP_FEATURES		+= exceptions
 LOCAL_STATIC_LIBRARIES 	:= PowerAuth2
 LOCAL_LDLIBS            := -llog
 ifeq ($(NDK_DEBUG),1)
-	LOCAL_LDFLAGS       := -Wl,--exclude-libs,ALL
+	LOCAL_LDFLAGS       := -Wl,--hash-style=both,--exclude-libs,ALL
 else
-	LOCAL_LDFLAGS       := -Wl,-s,--exclude-libs,ALL
+	LOCAL_LDFLAGS       := -Wl,--hash-style=both,-s,--exclude-libs,ALL
 endif
 
 LOCAL_C_INCLUDES := \


### PR DESCRIPTION
Fixes rare problem with `.so` dynamic library linking on some devices.