### PR TITLE
iOS: Fixed #248: Keychain workaround for iOS 13 simulator

### DIFF
--- a/scripts/ios-build-libraries.sh
+++ b/scripts/ios-build-libraries.sh
@@ -229,7 +229,6 @@ function COPY_SOURCE_FILES
 	COPY_SRC_DIR "keychain"   	"$SRC" "$DST" 0
 	COPY_SRC_DIR "token"      	"$SRC" "$DST" 0
 	COPY_SRC_DIR "system"     	"$SRC" "$DST" 0
-	COPY_SRC_DIR "util"       	"$SRC" "$DST" 0
 	COPY_SRC_DIR "watch"      	"$SRC" "$DST" 0
 	
 	# And finally, top level header..


### PR DESCRIPTION
This PR also fixes build problem, introduced in #241. The `util` folder is no longer in the project tree.