### PR TITLE
Broken cancel in PA2AsyncOperation

### DIFF
--- a/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		BFD27D8721144DA20020ABA4 /* PowerAuthInvalidCurveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD27D8621144DA20020ABA4 /* PowerAuthInvalidCurveTests.m */; };
 		BFD386621F2B528600F74FF9 /* TestConfig in Resources */ = {isa = PBXBuildFile; fileRef = BFD386611F2B528600F74FF9 /* TestConfig */; };
 		BFD386671F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD386661F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m */; };
+		BFDE2247242A1F0800D4FEB2 /* PA2AsyncOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDE2246242A1F0800D4FEB2 /* PA2AsyncOperationTests.m */; };
 		BFDFED9520BEEF730094138A /* PA2CoreLog.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFED9420BEEF730094138A /* PA2CoreLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFDFED9820BEEFAC0094138A /* PA2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDFED9620BEEFAC0094138A /* PA2Log.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFDFED9920BEEFAC0094138A /* PA2Log.m in Sources */ = {isa = PBXBuildFile; fileRef = BFDFED9720BEEFAC0094138A /* PA2Log.m */; };
@@ -402,6 +403,7 @@
 		BFD386611F2B528600F74FF9 /* TestConfig */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestConfig; sourceTree = SOURCE_ROOT; };
 		BFD386651F2B6BE700F74FF9 /* PowerAuthTestServerConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PowerAuthTestServerConfig.h; sourceTree = "<group>"; };
 		BFD386661F2B6BE700F74FF9 /* PowerAuthTestServerConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PowerAuthTestServerConfig.m; sourceTree = "<group>"; };
+		BFDE2246242A1F0800D4FEB2 /* PA2AsyncOperationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2AsyncOperationTests.m; sourceTree = "<group>"; };
 		BFDFED9420BEEF730094138A /* PA2CoreLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PA2CoreLog.h; sourceTree = "<group>"; };
 		BFDFED9620BEEFAC0094138A /* PA2Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2Log.h; sourceTree = "<group>"; };
 		BFDFED9720BEEFAC0094138A /* PA2Log.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2Log.m; sourceTree = "<group>"; };
@@ -683,6 +685,7 @@
 				BFAF730A1EAA8467005E7572 /* PowerAuthServerSOAP */,
 				BF4DBCCF1CDF9CDE008F3A47 /* PA2CoreTestsWrapper.mm */,
 				BF2347271F6C13CC0040FD0F /* PA2PublicObjectsTests.mm */,
+				BFDE2246242A1F0800D4FEB2 /* PA2AsyncOperationTests.m */,
 				BFAF73071EAA83AD005E7572 /* PowerAuthSDKTests.m */,
 				BF7751121FC48A1A008455A6 /* PowerAuthTokenTests.m */,
 				BF9EED2020372AEB001D8DF8 /* PowerAuthConcurrencyTests.m */,
@@ -1099,6 +1102,7 @@
 				BFAF73081EAA83AD005E7572 /* PowerAuthSDKTests.m in Sources */,
 				BF7751131FC48A1A008455A6 /* PowerAuthTokenTests.m in Sources */,
 				BF20EA991EACB21E00733D91 /* CXMLDocument_CreationExtensions.m in Sources */,
+				BFDE2247242A1F0800D4FEB2 /* PA2AsyncOperationTests.m in Sources */,
 				BF20EA8C1EACB17600733D91 /* CXMLNamespaceNode.m in Sources */,
 				BF20EA861EACB17600733D91 /* CXHTMLDocument.m in Sources */,
 				BF20EA9A1EACB21E00733D91 /* CXMLNode_CreationExtensions.m in Sources */,
@@ -1316,10 +1320,9 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = KTT9G859MR;
 				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../include",
-					"$(PROJECT_DIR)/../cc7/include",
-					"$(PROJECT_DIR)/../cc7/openssl/ios/include",
+					"$(inherited)",
 					/usr/include/libxml2,
+					"$(PROJECT_DIR)/Classes",
 				);
 				INFOPLIST_FILE = TestClasses/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1333,10 +1336,9 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = KTT9G859MR;
 				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../include",
-					"$(PROJECT_DIR)/../cc7/include",
-					"$(PROJECT_DIR)/../cc7/openssl/ios/include",
+					"$(inherited)",
 					/usr/include/libxml2,
+					"$(PROJECT_DIR)/Classes",
 				);
 				INFOPLIST_FILE = TestClasses/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/proj-xcode/TestClasses/PA2AsyncOperationTests.m
+++ b/proj-xcode/TestClasses/PA2AsyncOperationTests.m
@@ -1,0 +1,195 @@
+/**
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import <PowerAuth2/PowerAuth2.h>
+#import "AsyncHelper.h"
+
+#import "networking/private/client/PA2AsyncOperation.h"
+
+@interface PA2AsyncOperationTests : XCTestCase
+@end
+
+@implementation PA2AsyncOperationTests
+{
+	NSOperationQueue * _queue;
+}
+
+#pragma mark - Helpers
+
+- (NSOperationQueue*) serialQueue
+{
+	if (!_queue) {
+		_queue = [[NSOperationQueue alloc] init];
+		_queue.maxConcurrentOperationCount = 1;
+		_queue.name = @"PA2AsyncOperationTests_Serial";
+	}
+	return _queue;
+}
+
+
+- (void) completeOperationWithCancel:(PA2AsyncOperation*)op
+							 waiting:(AsyncHelper*)waiting
+						  afterDelay:(NSTimeInterval)delay
+{
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		[op cancel];
+		[waiting reportCompletion:@"cancel"];
+	});
+}
+
+- (void) completeOperationWithResult:(NSString*)result
+						   operation:(PA2AsyncOperation*)op
+							 waiting:(AsyncHelper*)waiting
+						  afterDelay:(NSTimeInterval)delay
+{
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		[op completeWithResult:result error:nil];
+		[waiting reportCompletion:result];
+	});
+}
+
+- (void) completeOperationWithError:(NSError*)error
+						  operation:(PA2AsyncOperation*)op
+							waiting:(AsyncHelper*)waiting
+						 afterDelay:(NSTimeInterval)delay
+{
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		[op completeWithResult:nil error:error];
+		[waiting reportCompletion:error];
+	});
+}
+
+#pragma mark - Tests
+
+- (void) testAsyncOperationSuccessExecution
+{
+	for (int i = 0; i < 3; i++) {
+		__block BOOL executed = NO;
+		__block BOOL canceled = NO;
+		__block NSInteger reported = 0;
+		NSString * result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+			PA2AsyncOperation * operation = [[PA2AsyncOperation alloc] initWithReportQueue:dispatch_get_main_queue()];
+			operation.executionBlock = ^id(PA2AsyncOperation *op) {
+				executed = YES;
+				[self completeOperationWithResult:@"success" operation:op waiting:waiting afterDelay:0.1];
+				return nil;
+			};
+			operation.cancelBlock = ^(PA2AsyncOperation *op, id operationTask) {
+				canceled = YES;
+			};
+			operation.reportBlock = ^(PA2AsyncOperation *op) {
+				reported++;
+			};
+			[[self serialQueue] addOperation:operation];
+		}];
+		XCTAssertEqual(YES, executed);
+		XCTAssertEqual(NO, canceled);
+		XCTAssertEqual(1, reported);
+		XCTAssertEqual(@"success", result);
+	}
+}
+
+- (void) testAsyncOperationFailureExecution
+{
+	for (int i = 0; i < 3; i++) {
+		__block BOOL executed = NO;
+		__block BOOL canceled = NO;
+		__block NSInteger reported = 0;
+		id result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+			PA2AsyncOperation * operation = [[PA2AsyncOperation alloc] initWithReportQueue:dispatch_get_main_queue()];
+			operation.executionBlock = ^id(PA2AsyncOperation *op) {
+				executed = YES;
+				NSError * error = [[NSError alloc] initWithDomain:@"TestDomain" code:99 userInfo:nil];
+				[self completeOperationWithError:error operation:op waiting:waiting afterDelay:0.1];
+				return nil;
+			};
+			operation.cancelBlock = ^(PA2AsyncOperation *op, id operationTask) {
+				canceled = YES;
+			};
+			operation.reportBlock = ^(PA2AsyncOperation *op) {
+				reported++;
+			};
+			[[self serialQueue] addOperation:operation];
+		} wait:2.0];
+		XCTAssertEqual(YES, executed);
+		XCTAssertEqual(NO, canceled);
+		XCTAssertEqual(1, reported);
+		XCTAssertTrue([result isKindOfClass:[NSError class]]);
+		XCTAssertEqual(@"TestDomain", [(NSError*)result domain]);
+		XCTAssertEqual(99, [(NSError*)result code]);
+	}
+}
+
+- (void) testAsyncOperationCancel
+{
+	for (int i = 0; i < 3; i++) {
+		__block BOOL executed = NO;
+		__block BOOL canceled = NO;
+		__block NSInteger reported = 0;
+		id result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+			PA2AsyncOperation * operation = [[PA2AsyncOperation alloc] initWithReportQueue:dispatch_get_main_queue()];
+			operation.executionBlock = ^id(PA2AsyncOperation *op) {
+				executed = YES;
+				[self completeOperationWithCancel:op waiting:waiting afterDelay:0.1];
+				return nil;
+			};
+			operation.cancelBlock = ^(PA2AsyncOperation *op, id operationTask) {
+				canceled = YES;
+			};
+			operation.reportBlock = ^(PA2AsyncOperation *op) {
+				reported++;
+			};
+			[[self serialQueue] addOperation:operation];
+		} wait:2.0];
+		XCTAssertEqual(executed, YES);
+		XCTAssertEqual(canceled, YES);
+		XCTAssertEqual(0, reported);
+		XCTAssertEqual(@"cancel", result);
+	}
+}
+
+- (void) testAsyncOperationImmediateCancel
+{
+	for (int i = 0; i < 3; i++) {
+		__block BOOL executed = NO;
+		__block BOOL canceled = NO;
+		__block NSInteger reported = 0;
+		id result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+			PA2AsyncOperation * operation = [[PA2AsyncOperation alloc] initWithReportQueue:dispatch_get_main_queue()];
+			operation.executionBlock = ^id(PA2AsyncOperation *op) {
+				executed = YES;
+				[op cancel];
+				[self completeOperationWithResult:@"success" operation:op waiting:waiting afterDelay:0.3];
+				return nil;
+			};
+			operation.cancelBlock = ^(PA2AsyncOperation *op, id operationTask) {
+				[waiting reportCompletion:@"cancel-handler"];
+				canceled = YES;
+			};
+			operation.reportBlock = ^(PA2AsyncOperation *op) {
+				reported++;
+			};
+			[[self serialQueue] addOperation:operation];
+		} wait:2.0];
+		XCTAssertEqual(executed, YES);
+		XCTAssertEqual(canceled, YES);
+		XCTAssertEqual(0, reported);
+		XCTAssertEqual(@"cancel-handler", result);
+	}
+}
+
+@end

--- a/proj-xcode/TestClasses/PowerAuthServerSOAP/AsyncHelper.m
+++ b/proj-xcode/TestClasses/PowerAuthServerSOAP/AsyncHelper.m
@@ -72,6 +72,7 @@
 		if (triggered == 0) {
 			break;
 		}
+		--attempts;
 	}
 	if (triggered != 0) {
 		@throw [NSException exceptionWithName:@"SoapApi" reason:@"waitForCompletion timed out" userInfo:nil];


### PR DESCRIPTION
- Fixed broken `PA2AsyncOperation` cancelation.
- Added unit tests for `PA2AsyncOperation`
- Fixed limited delay in `AsyncHelper` test helper.