### PR TITLE
Core: Fix #303: V2 signature calculation before protocol upgrade

### DIFF
--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -631,7 +631,8 @@ namespace powerAuth
 		const std::string & app_secret = request.isOfflineRequest() ? protocol::PA_OFFLINE_APP_SECRET : _setup.applicationSecret;
 		cc7::ByteArray data = protocol::NormalizeDataForSignature(request.method, request.uri, out.nonce, request.body, app_secret);
 		cc7::ByteArray ctr_data = _pd->isV3() ? _pd->signatureCounterData : protocol::SignatureCounterToData(_pd->signatureCounter);
-		out.signature = protocol::CalculateSignature(plain_keys, signature_factor, ctr_data, data, !request.isOfflineRequest());
+		const bool base64_sig_format = !request.isOfflineRequest() && _pd->isV3();
+		out.signature = protocol::CalculateSignature(plain_keys, signature_factor, ctr_data, data, base64_sig_format);
 		if (out.signature.empty()) {
 			CC7_LOG("Session %p, %d: Sign: Signature calculation failed.", this, sessionIdentifier());
 			return EC_Encryption;

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -1134,14 +1134,12 @@ namespace powerAuth
 					return EC_WrongParam;
 				}
 				// Everything looks fine, we can commit new data.
-				// Keep ctr_byte value from the current counter.
-				cc7::byte ctr_byte = (cc7::byte)(_pd->signatureCounter & 0xFF);
 				_pd->signatureCounterData = ctr_data;
 				_pd->signatureCounter = 0;
 				_pd->flags.waitingForVaultUnlock = 0;
-				// V3.1: Also store ctr_byte and flag that value is valid.
-				_pd->signatureCounterByte = ctr_byte;
-				_pd->flags.hasSignatureCounterByte = 1;
+				// V3.1: Despite the fact that we still have a local counter, it might be still out of the sync.
+				//       So, mark the counter byte as invalid, just like we do for migration from V3 to V3.1.
+				_pd->flags.hasSignatureCounterByte = 0;
 				return EC_Ok;
 			}
 			default:

--- a/src/PowerAuth/protocol/ProtocolUtils.cpp
+++ b/src/PowerAuth/protocol/ProtocolUtils.cpp
@@ -381,7 +381,7 @@ namespace protocol
 	}
 	
 	
-	std::string CalculateSignature(const SignatureKeys & sk, SignatureFactor factor, const cc7::ByteRange & ctr_data, const cc7::ByteRange & data, bool online)
+	std::string CalculateSignature(const SignatureKeys & sk, SignatureFactor factor, const cc7::ByteRange & ctr_data, const cc7::ByteRange & data, bool base64_format)
 	{
 		// Prepare keys into one linear vector
 		std::vector<const cc7::ByteArray*> keys;
@@ -398,7 +398,7 @@ namespace protocol
 		// Pepare byte array for online signature or final string for offline signature.
 		cc7::ByteArray signature_bytes;
 		std::string signature_string;
-		if (online) {
+		if (base64_format) {
 			signature_bytes.reserve(keys.size() * 16);
 		} else {
 			signature_string.reserve(keys.size() * 8 + keys.size() - 1);
@@ -427,7 +427,7 @@ namespace protocol
 				CC7_ASSERT(false, "HMAC_SHA256() calculation failed.");
 				return std::string();
 			}
-			if (online) {
+			if (base64_format) {
 				// For new online signature, just append last 16 bytes of HMAC result.
 				// We'll calculate final signature string later.
 				signature_bytes.append(signature_factor_bytes.byteRange().subRangeFrom(16));
@@ -440,7 +440,7 @@ namespace protocol
 				signature_string.append(signature_factor);
 			}
 		}
-		if (online) {
+		if (base64_format) {
 			// Now calculate a final Base64 string for online signature
 			cc7::Base64_Encode(signature_bytes, 0, signature_string);
 		}

--- a/src/PowerAuth/protocol/ProtocolUtils.h
+++ b/src/PowerAuth/protocol/ProtocolUtils.h
@@ -105,7 +105,7 @@ namespace protocol
 								   SignatureFactor factor,
 								   const cc7::ByteRange & ctr_data,
 								   const cc7::ByteRange & data,
-								   bool online);
+								   bool base64_format);
 	
 	/**
 	 Prepares exact data for signature calculation:


### PR DESCRIPTION
This PR fixes both issues related to the protocol upgrade from V2 to V3.1. Ticket #302, #303 