### PR TITLE
Issues/311 biometry deadlock

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -154,6 +154,12 @@ public class BiometricAuthentication {
                     PA2Log.e("BiometricAuthentication.authenticate() failed with exception: " + e.getMessage());
                     exception = e;
                     status = BiometricStatus.NOT_AVAILABLE;
+
+                } catch (IllegalArgumentException e) {
+                    // Failed to authenticate due to a wrong configuration.
+                    PA2Log.e("BiometricAuthentication.authenticate() failed with exception: " + e.getMessage());
+                    exception = new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeWrongParameter, e.getMessage());
+                    status = BiometricStatus.NOT_AVAILABLE;
                 }
             }
             // Failed to use biometric authentication. At first, we should cleanup the possible stored

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.text.TextUtils;
 
 import java.util.Arrays;
 
@@ -134,7 +135,7 @@ public class BiometricAuthenticationRequest {
          * @return Instance of {@link BiometricAuthenticationRequest} object.
          */
         public BiometricAuthenticationRequest build() {
-            if (title == null || description == null) {
+            if (TextUtils.isEmpty(title) || TextUtils.isEmpty(description)) {
                 throw new IllegalArgumentException("Title and description is required.");
             }
             if (keyToProtect == null) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -808,7 +808,7 @@ public class PowerAuthSDK {
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @NonNull
-    public ICancelable commitActivation(final @NonNull Context context, FragmentManager fragmentManager, String title, String description, @NonNull final String password, final ICommitActivationWithBiometryListener callback) {
+    public ICancelable commitActivation(final @NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull String title, @NonNull String description, @NonNull final String password, final @NonNull ICommitActivationWithBiometryListener callback) {
         return authenticateUsingBiometry(context, fragmentManager, title, description, true, new IBiometricAuthenticationCallback() {
             @Override
             public void onBiometricDialogCancelled(boolean userCancel) {
@@ -1422,7 +1422,7 @@ public class PowerAuthSDK {
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @Nullable
-    public ICancelable addBiometryFactor(@NonNull final Context context, final FragmentManager fragmentManager, final String title, final String description, String password, @NonNull final IAddBiometryFactorListener listener) {
+    public ICancelable addBiometryFactor(@NonNull final Context context, final @NonNull FragmentManager fragmentManager, final @NonNull String title, final @NonNull String description, @NonNull String password, @NonNull final IAddBiometryFactorListener listener) {
 
         // Initial authentication object, used for vault unlock call on server
         final PowerAuthAuthentication authAuthentication = new PowerAuthAuthentication();
@@ -1639,7 +1639,7 @@ public class PowerAuthSDK {
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @NonNull
-    public ICancelable authenticateUsingBiometry(Context context, FragmentManager fragmentManager, String title, String description, final IBiometricAuthenticationCallback callback) {
+    public ICancelable authenticateUsingBiometry(@NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull String title, @NonNull String description, final @NonNull IBiometricAuthenticationCallback callback) {
         return authenticateUsingBiometry(context, fragmentManager, title, description, false, callback);
     }
 
@@ -1657,7 +1657,7 @@ public class PowerAuthSDK {
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @NonNull
-    private ICancelable authenticateUsingBiometry(final @NonNull Context context, final @NonNull FragmentManager fragmentManager, final @NonNull String title, final @NonNull String description, final boolean forceGenerateNewKey, final IBiometricAuthenticationCallback callback) {
+    private ICancelable authenticateUsingBiometry(final @NonNull Context context, final @NonNull FragmentManager fragmentManager, final @NonNull String title, final @NonNull String description, final boolean forceGenerateNewKey, final @NonNull IBiometricAuthenticationCallback callback) {
 
         final byte[] biometryKey;
         if (forceGenerateNewKey) { // new key has to be generated

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -388,7 +388,7 @@ public class PowerAuthSDK {
      *
      * @return Reference to {@code PowerAuthTokenStore} instance.
      */
-    public synchronized PowerAuthTokenStore getTokenStore() {
+    public synchronized @NonNull PowerAuthTokenStore getTokenStore() {
         if (mTokenStore == null) {
             PA2Keychain tokenStoreKeychain = new PA2Keychain(mKeychainConfiguration.getKeychainTokenStoreId());
             mTokenStore = new PowerAuthTokenStore(this, tokenStoreKeychain, mClient);
@@ -406,7 +406,7 @@ public class PowerAuthSDK {
      *
      * @return low level {@link Session} object
      */
-    public Session getSession() {
+    public @NonNull Session getSession() {
         return mSession;
     }
 
@@ -1494,7 +1494,7 @@ public class PowerAuthSDK {
      * @return {@link ICancelable} object associated with the running HTTP request.
      */
     public @Nullable
-    ICancelable addBiometryFactor(@NonNull final Context context, String password, final byte[] encryptedBiometryKey, @NonNull final IAddBiometryFactorListener listener) {
+    ICancelable addBiometryFactor(@NonNull final Context context, @NonNull String password, final @NonNull byte[] encryptedBiometryKey, @NonNull final IAddBiometryFactorListener listener) {
         final PowerAuthAuthentication authAuthentication = new PowerAuthAuthentication();
         authAuthentication.usePossession = true;
         authAuthentication.usePassword = password;
@@ -1593,7 +1593,7 @@ public class PowerAuthSDK {
      * @return {@link ICancelable} object associated with the running HTTP request.
      */
     public @Nullable
-    ICancelable validatePasswordCorrect(@NonNull Context context, String password, @NonNull final IValidatePasswordListener listener) {
+    ICancelable validatePasswordCorrect(@NonNull Context context, @NonNull String password, @NonNull final IValidatePasswordListener listener) {
 
         // Prepare authentication object
         PowerAuthAuthentication authentication = new PowerAuthAuthentication();
@@ -1785,7 +1785,7 @@ public class PowerAuthSDK {
      *
      * @param runnable Runnable wrapping a callback that's supposed to be dispatched.
      */
-    void dispatchCallback(Runnable runnable) {
+    void dispatchCallback(@NonNull Runnable runnable) {
         mCallbackDispatcher.dispatchCallback(runnable);
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/ICallbackDispatcher.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/ICallbackDispatcher.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.sdk.impl;
 
+import android.support.annotation.NonNull;
+
 /**
  * Dispatcher for callbacks for SDK public APIs.
  *
@@ -28,5 +30,5 @@ public interface ICallbackDispatcher {
      *
      * @param runnable callback wrapped in a runnable to be dispatched.
      */
-    void dispatchCallback(Runnable runnable);
+    void dispatchCallback(@NonNull Runnable runnable);
 }


### PR DESCRIPTION
- Fixed possible `BiometricAuthentication` deadlock in case of wrong biometric authentication request
- Added missing nullability annotations to several `PowerAuthSDK` methods