### PR TITLE
Android Keychain unit tests

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/KeychainFactoryTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/KeychainFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.keychain;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class KeychainFactoryTest {
+
+    private Context androidContext;
+
+    private static final String KEYCHAIN_1_NAME = "com.wultra.test.keychain1";
+    private static final String KEYCHAIN_2_NAME = "com.wultra.test.keychain2";
+
+    @Before
+    public void setUp() {
+        androidContext = InstrumentationRegistry.getInstrumentation().getContext();
+        assertNotNull(androidContext);
+    }
+
+    @Test
+    public void testCachedKeychains() throws Exception {
+        final Keychain keychain1_a = KeychainFactory.getKeychain(androidContext, KEYCHAIN_1_NAME, KeychainProtection.NONE);
+        final Keychain keychain1_b = KeychainFactory.getKeychain(androidContext, KEYCHAIN_1_NAME, KeychainProtection.NONE);
+        assertEquals(keychain1_a, keychain1_b);
+        final Keychain keychain2_a = KeychainFactory.getKeychain(androidContext, KEYCHAIN_2_NAME, KeychainProtection.NONE);
+        final Keychain keychain2_b = KeychainFactory.getKeychain(androidContext, KEYCHAIN_2_NAME, KeychainProtection.NONE);
+        assertEquals(keychain2_a, keychain2_b);
+    }
+
+    @Test
+    public void testMaximumKeychainProtection() throws Exception {
+        final @KeychainProtection int currentProtection = KeychainFactory.getKeychainProtectionSupportedOnDevice(androidContext);
+        if (currentProtection == KeychainProtection.STRONGBOX) {
+            // Nothing to do in this test, when the device supports maximum keychain protection.
+            return;
+        }
+        try {
+            final Keychain keychain = KeychainFactory.getKeychain(androidContext, KEYCHAIN_2_NAME, KeychainProtection.STRONGBOX);
+            fail();
+        } catch (PowerAuthErrorException e) {
+            assertEquals(PowerAuthErrorCodes.PA2ErrorCodeInsufficientKeychainProtection, e.getPowerAuthErrorCode());
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
@@ -18,7 +18,7 @@ package io.getlime.security.powerauth.keychain.impl;
 
 import android.support.annotation.NonNull;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,38 +26,29 @@ import io.getlime.security.powerauth.keychain.Keychain;
 
 import static org.junit.Assert.*;
 
-public class BaseKeychainTest {
+public abstract class BaseKeychainTest {
 
     // Test data
 
-    public byte[] data_Empty;
-    public byte[] data_NotEmpty;
-    public final String string_Empty = "";
-    public final String string_NotEmpty = "Hello world!";
-    public Set<String> set_Empty;
-    public Set<String> set_NotEmpty;
+    public static final byte[] TEST_DATA_EMPTY = new byte[0];
+    public static final byte[] TEST_DATA_NOT_EMPTY = new byte[] { 'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd' , '!' };
+    public static final String TEST_STRING_EMPTY = "";
+    public static final String TEST_STRING_NOT_EMPTY = "Hello world!";
+    public static final Set<String> TEST_SET_EMPTY = new HashSet<>();
+    public static final Set<String> TEST_SET_NOT_EMPTY = new HashSet<>(Arrays.asList("This", "is", "test", "set", "wultra.com"));
 
     public void setupTestData() {
-        // Setup test data
-        data_Empty = new byte[0];
-        data_NotEmpty = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.".getBytes();
-
-        set_Empty = Collections.emptySet();
-        set_NotEmpty = new HashSet<>();
-        set_NotEmpty.add(string_Empty);
-        set_NotEmpty.add(string_NotEmpty);
-        set_NotEmpty.add("wultra.com");
     }
 
     public void fillTestValues(@NonNull Keychain keychain) throws Exception {
         keychain.putBoolean(true, "test.true");
         keychain.putBoolean(false, "test.false");
-        keychain.putData(data_Empty, "test.data_Empty");
-        keychain.putData(data_NotEmpty, "test.data_NotEmpty");
-        keychain.putString(string_Empty, "test.string_Empty");
-        keychain.putString(string_NotEmpty, "test.string_NotEmpty");
-        keychain.putStringSet(set_Empty, "test.set_Empty");
-        keychain.putStringSet(set_NotEmpty, "test.set_NotEmpty");
+        keychain.putData(TEST_DATA_EMPTY, "test.data_Empty");
+        keychain.putData(TEST_DATA_NOT_EMPTY, "test.data_NotEmpty");
+        keychain.putString(TEST_STRING_EMPTY, "test.string_Empty");
+        keychain.putString(TEST_STRING_NOT_EMPTY, "test.string_NotEmpty");
+        keychain.putStringSet(TEST_SET_EMPTY, "test.set_Empty");
+        keychain.putStringSet(TEST_SET_NOT_EMPTY, "test.set_NotEmpty");
         keychain.putFloat(0.f, "test.zeroFloat");
         keychain.putFloat(-99.f, "test.negativeFloat");
         keychain.putFloat( 3.14159f, "test.positiveFloat");
@@ -70,21 +61,23 @@ public class BaseKeychainTest {
         assertTrue(keychain.getBoolean("test.true", false));
         assertFalse(keychain.getBoolean("test.false", true));
         assertNull(keychain.getData("test.data_Empty"));
-        assertArrayEquals(data_NotEmpty, keychain.getData("test.data_NotEmpty"));
+        assertArrayEquals(TEST_DATA_NOT_EMPTY, keychain.getData("test.data_NotEmpty"));
         if (emptyStringIsNull) {
             assertNull(keychain.getString("test.string_Empty"));
         } else {
-            assertEquals(string_Empty, keychain.getString("test.string_Empty", string_NotEmpty));
+            assertEquals(TEST_STRING_EMPTY, keychain.getString("test.string_Empty", TEST_STRING_NOT_EMPTY));
         }
-        assertEquals(string_NotEmpty, keychain.getString("test.string_NotEmpty", string_Empty));
+        assertEquals(TEST_STRING_NOT_EMPTY, keychain.getString("test.string_NotEmpty", TEST_STRING_EMPTY));
         final Set<String> emptySet = keychain.getStringSet("test.set_Empty");
         assertNotNull(emptySet);
         assertEquals(0, emptySet.size());
         final Set<String> notEmptySet = keychain.getStringSet("test.set_NotEmpty");
         assertNotNull(notEmptySet);
-        assertEquals(3, notEmptySet.size());
-        assertTrue(notEmptySet.contains(string_Empty));
-        assertTrue(notEmptySet.contains(string_NotEmpty));
+        assertEquals(TEST_SET_NOT_EMPTY.size(), notEmptySet.size());
+        assertTrue(notEmptySet.contains("This"));
+        assertTrue(notEmptySet.contains("is"));
+        assertTrue(notEmptySet.contains("test"));
+        assertTrue(notEmptySet.contains("set"));
         assertTrue(notEmptySet.contains("wultra.com"));
         assertEquals(0.f, keychain.getFloat("test.zeroFloat", -1f), 0.0);
         assertEquals(-99.f, keychain.getFloat("test.negativeFloat", 0.f), 0.0);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.keychain.impl;
+
+import android.support.annotation.NonNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.getlime.security.powerauth.keychain.Keychain;
+
+import static org.junit.Assert.*;
+
+public class BaseKeychainTest {
+
+    // Test data
+
+    public byte[] data_Empty;
+    public byte[] data_NotEmpty;
+    public final String string_Empty = "";
+    public final String string_NotEmpty = "Hello world!";
+    public Set<String> set_Empty;
+    public Set<String> set_NotEmpty;
+
+    public void setupTestData() {
+        // Setup test data
+        data_Empty = new byte[0];
+        data_NotEmpty = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.".getBytes();
+
+        set_Empty = Collections.emptySet();
+        set_NotEmpty = new HashSet<>();
+        set_NotEmpty.add(string_Empty);
+        set_NotEmpty.add(string_NotEmpty);
+        set_NotEmpty.add("wultra.com");
+    }
+
+    public void fillTestValues(@NonNull Keychain keychain) throws Exception {
+        keychain.putBoolean(true, "test.true");
+        keychain.putBoolean(false, "test.false");
+        keychain.putData(data_Empty, "test.data_Empty");
+        keychain.putData(data_NotEmpty, "test.data_NotEmpty");
+        keychain.putString(string_Empty, "test.string_Empty");
+        keychain.putString(string_NotEmpty, "test.string_NotEmpty");
+        keychain.putStringSet(set_Empty, "test.set_Empty");
+        keychain.putStringSet(set_NotEmpty, "test.set_NotEmpty");
+        keychain.putFloat(0.f, "test.zeroFloat");
+        keychain.putFloat(-99.f, "test.negativeFloat");
+        keychain.putFloat( 3.14159f, "test.positiveFloat");
+        keychain.putLong(0, "test.zeroLong");
+        keychain.putLong(7710177, "test.long");
+        keychain.putLong(-303, "test.negativeLong");
+    }
+
+    public void testFilledValues(@NonNull Keychain keychain) throws Exception {
+        assertTrue(keychain.getBoolean("test.true", false));
+        assertFalse(keychain.getBoolean("test.false", true));
+        assertNull(keychain.getData("test.data_Empty"));
+        assertArrayEquals(data_NotEmpty, keychain.getData("test.data_NotEmpty"));
+        assertEquals(string_Empty, keychain.getString("test.string_Empty", string_NotEmpty));
+        assertEquals(string_NotEmpty, keychain.getString("test.string_NotEmpty", string_Empty));
+        final Set<String> emptySet = keychain.getStringSet("test.set_Empty");
+        assertNotNull(emptySet);
+        assertEquals(0, emptySet.size());
+        final Set<String> notEmptySet = keychain.getStringSet("test.set_NotEmpty");
+        assertNotNull(notEmptySet);
+        assertEquals(3, notEmptySet.size());
+        assertTrue(notEmptySet.contains(string_Empty));
+        assertTrue(notEmptySet.contains(string_NotEmpty));
+        assertTrue(notEmptySet.contains("wultra.com"));
+        assertEquals(0.f, keychain.getFloat("test.zeroFloat", -1f), 0.0);
+        assertEquals(-99.f, keychain.getFloat("test.negativeFloat", 0.f), 0.0);
+        assertEquals(3.14159f, keychain.getFloat("test.positiveFloat", 0.f), 0.0);
+        assertEquals(0, keychain.getLong("test.zeroLong", -1));
+        assertEquals(7710177, keychain.getLong("test.long", 0));
+        assertEquals(-303, keychain.getLong("test.negativeLong", 0));
+    }
+
+    public void testDefaultValues(@NonNull Keychain keychain) throws Exception {
+        assertTrue(keychain.getBoolean("test.unknownKey", true));
+        assertEquals(101, keychain.getLong("test.unknownKey", 101));
+        assertEquals("default", keychain.getString("test.unknownKey", "default"));
+        assertEquals(6.44f, keychain.getFloat("test.unknownKey", 6.44f), 0.0);
+        assertNull(keychain.getData("test.unknownKey"));
+        assertNull(keychain.getString("test.unknownKey"));
+        assertNull(keychain.getStringSet("test.unknownKey"));
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/BaseKeychainTest.java
@@ -66,12 +66,16 @@ public class BaseKeychainTest {
         keychain.putLong(-303, "test.negativeLong");
     }
 
-    public void testFilledValues(@NonNull Keychain keychain) throws Exception {
+    public void testFilledValues(@NonNull Keychain keychain, boolean emptyStringIsNull) throws Exception {
         assertTrue(keychain.getBoolean("test.true", false));
         assertFalse(keychain.getBoolean("test.false", true));
         assertNull(keychain.getData("test.data_Empty"));
         assertArrayEquals(data_NotEmpty, keychain.getData("test.data_NotEmpty"));
-        assertEquals(string_Empty, keychain.getString("test.string_Empty", string_NotEmpty));
+        if (emptyStringIsNull) {
+            assertNull(keychain.getString("test.string_Empty"));
+        } else {
+            assertEquals(string_Empty, keychain.getString("test.string_Empty", string_NotEmpty));
+        }
         assertEquals(string_NotEmpty, keychain.getString("test.string_NotEmpty", string_Empty));
         final Set<String> emptySet = keychain.getStringSet("test.set_Empty");
         assertNotNull(emptySet);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychainTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.keychain.impl;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.getlime.security.powerauth.keychain.Keychain;
+import io.getlime.security.powerauth.keychain.KeychainFactory;
+import io.getlime.security.powerauth.keychain.KeychainProtection;
+import io.getlime.security.powerauth.keychain.SymmetricKeyProvider;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class EncryptedKeychainTest extends BaseKeychainTest {
+
+    private static final String KEYCHAIN_NAME = "com.wultra.test.encryptedKeychain";
+
+    private Keychain keychain;
+    private @KeychainProtection int currentProtectionLevel;
+
+    @Before
+    public void setUp() throws Exception {
+
+        Context androidContext = InstrumentationRegistry.getInstrumentation().getContext();
+        assertNotNull(androidContext);
+
+        // At first test, whether the device supports at least SOFTWARE keychain protection.
+        currentProtectionLevel = KeychainFactory.getKeychainProtectionSupportedOnDevice(androidContext);
+        // Do not run this test, in case that device doesn't support enough protection level.
+        if (currentProtectionLevel == KeychainProtection.NONE) {
+            return;
+        }
+
+        SymmetricKeyProvider symmetricKeyProvider = SymmetricKeyProvider.getAesGcmKeyProvider("com.wultra.test.symmetricAesGcmKey", 256, true, null);
+        assertNotNull(symmetricKeyProvider);
+        symmetricKeyProvider.deleteSecretKey();
+
+        keychain = new EncryptedKeychain(androidContext, KEYCHAIN_NAME, symmetricKeyProvider);
+        assertNotNull(keychain);
+        keychain.removeAll();
+
+        setupTestData();
+    }
+
+    @Test
+    public void testKeychainUsage() throws Exception {
+
+        // Do not run this test, in case that device doesn't support enough protection level.
+        if (currentProtectionLevel > KeychainProtection.NONE) {
+            fillTestValues(keychain);
+            testFilledValues(keychain);
+            testDefaultValues(keychain);
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychainTest.java
@@ -69,7 +69,7 @@ public class EncryptedKeychainTest extends BaseKeychainTest {
         // Do not run this test, in case that device doesn't support enough protection level.
         if (currentProtectionLevel > KeychainProtection.NONE) {
             fillTestValues(keychain);
-            testFilledValues(keychain);
+            testFilledValues(keychain, false);
             testDefaultValues(keychain);
         }
     }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
@@ -37,8 +37,7 @@ public class KeychainMigrationTest extends BaseKeychainTest {
     private Context androidContext;
     private SymmetricKeyProvider symmetricKeyProvider;
     private SharedPreferences backingSharedPreferences;
-    private @KeychainProtection
-    int currentProtectionLevel;
+    private @KeychainProtection int currentProtectionLevel;
 
     private static final String KEYCHAIN_NAME = "com.wultra.test.migrationTest.keychainId";
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.keychain.impl;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.getlime.security.powerauth.keychain.KeychainFactory;
+import io.getlime.security.powerauth.keychain.KeychainProtection;
+import io.getlime.security.powerauth.keychain.SymmetricKeyProvider;
+import io.getlime.security.powerauth.keychain.impl.EncryptedKeychain;
+import io.getlime.security.powerauth.keychain.impl.LegacyKeychain;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class KeychainMigrationTest extends BaseKeychainTest {
+
+    private Context androidContext;
+    private SymmetricKeyProvider symmetricKeyProvider;
+    private SharedPreferences backingSharedPreferences;
+    private @KeychainProtection
+    int currentProtectionLevel;
+
+    private static final String KEYCHAIN_NAME = "com.wultra.test.migrationTest.keychainId";
+
+    @Before
+    public void setUp() {
+        androidContext = InstrumentationRegistry.getInstrumentation().getContext();
+        assertNotNull(androidContext);
+
+        // At first test, whether the device supports at least SOFTWARE keychain protection.
+        currentProtectionLevel = KeychainFactory.getKeychainProtectionSupportedOnDevice(androidContext);
+        // Do not run this test, in case that device doesn't support enough protection level.
+        if (currentProtectionLevel == KeychainProtection.NONE) {
+            return;
+        }
+
+        symmetricKeyProvider = SymmetricKeyProvider.getAesGcmKeyProvider("com.wultra.test.symmetricAesGcmKey", 256, true, null);
+        assertNotNull(symmetricKeyProvider);
+        symmetricKeyProvider.deleteSecretKey();
+
+        backingSharedPreferences =  androidContext.getSharedPreferences(KEYCHAIN_NAME, Context.MODE_PRIVATE);
+        assertNotNull(backingSharedPreferences);
+
+        setupTestData();
+    }
+
+    @Test
+    public void testKeychainMigration() throws Exception {
+
+        // Do not run this test, in case that device doesn't support enough protection level.
+        if (currentProtectionLevel == KeychainProtection.NONE) {
+            return;
+        }
+
+        // Prepare symmetric key provider
+        assertFalse(symmetricKeyProvider.containsSecretKey());
+
+        // Prepare legacy keychain
+        final LegacyKeychain legacyKeychain = new LegacyKeychain(androidContext, KEYCHAIN_NAME);
+        assertFalse(legacyKeychain.isEncrypted());
+
+        legacyKeychain.removeAll();
+
+        fillTestValues(legacyKeychain);
+        testFilledValues(legacyKeychain);
+
+        // Now try to migrate the keychain
+        assertFalse(EncryptedKeychain.isEncryptedContentInSharedPreferences(backingSharedPreferences));
+        final EncryptedKeychain encryptedKeychain = new EncryptedKeychain(androidContext, KEYCHAIN_NAME, symmetricKeyProvider);
+        assertTrue(encryptedKeychain.importFromLegacyKeychain(backingSharedPreferences));
+        assertTrue(symmetricKeyProvider.containsSecretKey());
+        assertTrue(EncryptedKeychain.isEncryptedContentInSharedPreferences(backingSharedPreferences));
+
+        testFilledValues(encryptedKeychain);
+    }
+
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
@@ -88,7 +88,7 @@ public class KeychainMigrationTest extends BaseKeychainTest {
         legacyKeychain.removeAll();
 
         fillTestValues(legacyKeychain);
-        testFilledValues(legacyKeychain);
+        testFilledValues(legacyKeychain, false);
 
         // Now try to migrate the keychain
         assertFalse(EncryptedKeychain.isEncryptedContentInSharedPreferences(backingSharedPreferences));
@@ -97,7 +97,7 @@ public class KeychainMigrationTest extends BaseKeychainTest {
         assertTrue(symmetricKeyProvider.containsSecretKey());
         assertTrue(EncryptedKeychain.isEncryptedContentInSharedPreferences(backingSharedPreferences));
 
-        testFilledValues(encryptedKeychain);
+        testFilledValues(encryptedKeychain, true);  // Empty string is treated as null after migration.
     }
 
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/KeychainMigrationTest.java
@@ -25,15 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.nio.charset.Charset;
-import java.util.HashSet;
-import java.util.Set;
-
 import io.getlime.security.powerauth.keychain.KeychainFactory;
 import io.getlime.security.powerauth.keychain.KeychainProtection;
 import io.getlime.security.powerauth.keychain.SymmetricKeyProvider;
-import io.getlime.security.powerauth.keychain.impl.EncryptedKeychain;
-import io.getlime.security.powerauth.keychain.impl.LegacyKeychain;
 
 import static org.junit.Assert.*;
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychainTest.java
@@ -49,7 +49,7 @@ public class LegacyKeychainTest extends BaseKeychainTest {
     @Test
     public void testKeychainUsage() throws Exception {
         fillTestValues(keychain);
-        testFilledValues(keychain);
+        testFilledValues(keychain, false);
         testDefaultValues(keychain);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychainTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychainTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.keychain.impl;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.getlime.security.powerauth.keychain.Keychain;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class LegacyKeychainTest extends BaseKeychainTest {
+
+    private static final String KEYCHAIN_NAME = "com.wultra.test.legacyKeychain";
+
+    private Keychain keychain;
+
+    @Before
+    public void setUp() throws Exception {
+        Context androidContext = InstrumentationRegistry.getInstrumentation().getContext();
+        assertNotNull(androidContext);
+        keychain = new LegacyKeychain(androidContext, KEYCHAIN_NAME);
+        assertNotNull(keychain);
+        keychain.removeAll();
+
+        setupTestData();
+    }
+
+    @Test
+    public void testKeychainUsage() throws Exception {
+        fillTestValues(keychain);
+        testFilledValues(keychain);
+        testDefaultValues(keychain);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
@@ -314,9 +314,16 @@ public class EncryptedKeychain implements Keychain {
             final @NonNull byte[] encodedValue;
             if (value instanceof String) {
                 final String string = (String)value;
+                if (string.isEmpty()) {
+                    // It's impossible to determine whether the stored value was string or Base64
+                    // encoded data. The most safe way to handle this situation is to remove such
+                    // value from the keychain.
+                    keysToRemove.add(entry.getKey());
+                    continue;
+                }
                 // Test whether the string is Base64 encoded sequence of bytes
                 final byte[] decodedBytes = Base64.decode(string, Base64.DEFAULT);
-                if (string.length() > 0 && Base64.encodeToString(decodedBytes, Base64.DEFAULT).trim().equals(string.trim())) {
+                if (Base64.encodeToString(decodedBytes, Base64.DEFAULT).trim().equals(string.trim())) {
                     // String contains Base64 encoded sequence of bytes.
                     encodedValue = valueEncoder.encode(decodedBytes);
                 } else {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
@@ -132,7 +132,7 @@ public class EncryptedKeychain implements Keychain {
 
     @Override
     public synchronized void putData(@Nullable byte[] data, @NonNull String key) {
-        setRawValue(key, data != null ? valueEncoder.encode(data) : null);
+        setRawValue(key, (data != null && data.length > 0) ? valueEncoder.encode(data) : null);
     }
 
     // String accessors
@@ -316,7 +316,7 @@ public class EncryptedKeychain implements Keychain {
                 final String string = (String)value;
                 // Test whether the string is Base64 encoded sequence of bytes
                 final byte[] decodedBytes = Base64.decode(string, Base64.DEFAULT);
-                if (Base64.encodeToString(decodedBytes, Base64.DEFAULT).trim().equals(string.trim())) {
+                if (string.length() > 0 && Base64.encodeToString(decodedBytes, Base64.DEFAULT).trim().equals(string.trim())) {
                     // String contains Base64 encoded sequence of bytes.
                     encodedValue = valueEncoder.encode(decodedBytes);
                 } else {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychain.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/LegacyKeychain.java
@@ -100,7 +100,7 @@ public class LegacyKeychain implements Keychain {
 
     @Override
     public synchronized void putData(@Nullable byte[] data, @NonNull String key) {
-        final String serializedData = data != null ? Base64.encodeToString(data, Base64.DEFAULT) : null;
+        final String serializedData = (data != null && data.length > 0) ? Base64.encodeToString(data, Base64.DEFAULT) : null;
         setStringValue(key, serializedData);
     }
 


### PR DESCRIPTION
This PR adds unit tests for `Keychain` and `KeychainFactory` interfaces.

The unit tests revealed that it's impossible to distinguish between previously stored empty string and stored empty array of bytes. Both situations leads to empty string to be set to the keychain. Due to this reason, the import to `EncryptedKeychain` removes all strings from the keychain. I think this is the most compatible approach, because previous `PA2Keychain` interface had no data nullability specified, so we had always to handle empty strings or data.