### PR TITLE
ActivationId and ActivationFingerprint is available after key-exchange

### DIFF
--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -151,14 +151,14 @@ namespace powerAuth
 		// MARK: - Activation -
 		
 		/**
-		 If the session has valid activation, then returns the activation identifier.
-		 Otherwise returns empty string.
+		 If the session has valid activation or state is SS_Activation2, then returns the
+		 activation identifier. Otherwise returns empty string.
 		 */
 		std::string activationIdentifier() const;
 		
 		/**
-		 If the session has valid activation, then returns decimalized fingerprint, calculated
-		 from device's public key. Otherwise returns empty string.
+		 If the session has valid activation or state is SS_Activation2, then returns
+		 decimalized fingerprint, calculated from device's public key. Otherwise returns empty string.
 		 
 		 Note: The value is equivalent to H_K_DEVICE_PUBLIC mentioned in PowerAuth crypto
 		 protocol documentation.

--- a/proj-xcode/PowerAuthLib.xcodeproj/xcshareddata/xcschemes/PA2_Release.xcscheme
+++ b/proj-xcode/PowerAuthLib.xcodeproj/xcshareddata/xcschemes/PA2_Release.xcscheme
@@ -68,6 +68,9 @@
                   Identifier = "PowerAuthInvalidCurveTests">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKProtocolUpgradeTests">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKTests">
                </Test>
                <Test

--- a/proj-xcode/TestClasses/PowerAuthSDKTests.m
+++ b/proj-xcode/TestClasses/PowerAuthSDKTests.m
@@ -422,6 +422,7 @@ static NSString * PA_Ver = @"3.1";
 	XCTAssertFalse([_sdk hasValidActivation]);
 	XCTAssertTrue([_sdk canStartActivation]);
 	XCTAssertNil(_sdk.activationIdentifier);
+	XCTAssertNil(_sdk.activationFingerprint);
 	
 	// 1) SERVER: initialize an activation on server (this is typically implemented in the internet banking application)
 	PATSActivationOtpValidationEnum otpValidation = activationOtp != nil ? PATSActivationOtpValidation_ON_KEY_EXCHANGE : PATSActivationOtpValidation_NONE;
@@ -456,6 +457,8 @@ static NSString * PA_Ver = @"3.1";
 	XCTAssertFalse([_sdk hasValidActivation]);
 	XCTAssertFalse([_sdk canStartActivation]);
 	XCTAssertTrue([activationData.activationId isEqualToString:_sdk.activationIdentifier]);
+	NSString * activationFingerprintBeforeCommit = _sdk.activationFingerprint;
+	XCTAssertNotNil(activationFingerprintBeforeCommit);
 	
 	// 2.1) CLIENT: Try to fetch status. At this point, it should not work! The activation is not completed yet.
 	PA2ActivationStatus * activationStatus = [self fetchActivationStatus];
@@ -506,6 +509,8 @@ static NSString * PA_Ver = @"3.1";
 	XCTAssertTrue([serverActivationStatus.activationName isEqualToString:_testServerConfig.userActivationName]);
 	// Test whether the device's public key fingerprint is equal on server and client.
 	XCTAssertTrue([serverActivationStatus.devicePublicKeyFingerprint isEqualToString:activationResult.activationFingerprint]);
+	XCTAssertTrue([serverActivationStatus.devicePublicKeyFingerprint isEqualToString:_sdk.activationFingerprint]);
+	XCTAssertTrue([serverActivationStatus.devicePublicKeyFingerprint isEqualToString:activationFingerprintBeforeCommit]);
 	
 	// This is just a cleanup. If remove will fail, then we don't report an error
 	if (removeAfter || !result) {

--- a/proj-xcode/TestClasses/PowerAuthSDKTests.m
+++ b/proj-xcode/TestClasses/PowerAuthSDKTests.m
@@ -421,6 +421,7 @@ static NSString * PA_Ver = @"3.1";
 	XCTAssertFalse([_sdk hasPendingActivation]);
 	XCTAssertFalse([_sdk hasValidActivation]);
 	XCTAssertTrue([_sdk canStartActivation]);
+	XCTAssertNil(_sdk.activationIdentifier);
 	
 	// 1) SERVER: initialize an activation on server (this is typically implemented in the internet banking application)
 	PATSActivationOtpValidationEnum otpValidation = activationOtp != nil ? PATSActivationOtpValidation_ON_KEY_EXCHANGE : PATSActivationOtpValidation_NONE;
@@ -454,7 +455,7 @@ static NSString * PA_Ver = @"3.1";
 	XCTAssertTrue([_sdk hasPendingActivation]);
 	XCTAssertFalse([_sdk hasValidActivation]);
 	XCTAssertFalse([_sdk canStartActivation]);
-	
+	XCTAssertTrue([activationData.activationId isEqualToString:_sdk.activationIdentifier]);
 	
 	// 2.1) CLIENT: Try to fetch status. At this point, it should not work! The activation is not completed yet.
 	PA2ActivationStatus * activationStatus = [self fetchActivationStatus];
@@ -596,6 +597,7 @@ static NSString * PA_Ver = @"3.1";
 		XCTAssertNotNil(task);
 	}];
 	XCTAssertNil(removeError);
+	XCTAssertNil(_sdk.activationIdentifier);
 	
 	// Cleanup, only if the SDK remove did fail
 	if (removeError) {

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -215,6 +215,8 @@ namespace powerAuth
 		LOCK_GUARD();
 		if (hasValidActivation()) {
 			return _pd->activationId;
+		} else if (hasPendingActivation()) {
+			return _ad->activationId;
 		}
 		return std::string();
 	}

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -225,8 +225,14 @@ namespace powerAuth
 	{
 		LOCK_GUARD();
 		std::string result;
-		if (hasValidActivation()) {
-			result = protocol::CalculateActivationFingerprint(_pd->devicePublicKey, _pd->serverPublicKey, _pd->activationId, _pd->protocolVersion());
+		if (hasValidActivation() || (hasPendingActivation() && _state == SS_Activation2)) {
+			if (_state == SS_Activation2) {
+				// Still pending activation
+				result = protocol::CalculateActivationFingerprint(_ad->devicePublicKeyData, _ad->serverPublicKeyData, _ad->activationId, Version_Latest);
+			} else {
+				// Has valid activation
+				result = protocol::CalculateActivationFingerprint(_pd->devicePublicKey, _pd->serverPublicKey, _pd->activationId, _pd->protocolVersion());
+			}
 			if (result.empty()) {
 				CC7_LOG("Session %p, %d: ActivationFingerprint: Unable to calculate activation fingerprint.", this, sessionIdentifier());
 			}
@@ -350,7 +356,7 @@ namespace powerAuth
 				break;
 			}
 			// So far so good, the last step is decimalization of device's public key
-			result.activationFingerprint = protocol::CalculateActivationFingerprint(_ad->devicePublicKeyData, _ad->serverPublicKeyData, param.activationId, Version_V3);
+			result.activationFingerprint = protocol::CalculateActivationFingerprint(_ad->devicePublicKeyData, _ad->serverPublicKeyData, param.activationId, Version_Latest);
 			if (result.activationFingerprint.empty()) {
 				CC7_LOG("Session %p, %d: Step 2: Unable to calculate activation fingerprint.", this, sessionIdentifier());
 				break;

--- a/src/PowerAuthTests/pa2SessionTests.cpp
+++ b/src/PowerAuthTests/pa2SessionTests.cpp
@@ -262,6 +262,7 @@ namespace powerAuthTests
 					ccstAssertTrue(s1.hasPendingActivation());
 					ccstAssertFalse(s1.hasValidActivation());
 					ccstAssertTrue(s1.activationIdentifier().empty());
+					ccstAssertTrue(s1.activationFingerprint().empty());
 					
 					if (break_in_step == 1) {
 						s1.resetSession();
@@ -270,6 +271,7 @@ namespace powerAuthTests
 						ccstAssertFalse(s1.hasPendingActivation());
 						ccstAssertFalse(s1.hasValidActivation());
 						ccstAssertTrue(s1.activationIdentifier().empty());
+						ccstAssertTrue(s1.activationFingerprint().empty());
 						continue;
 					}
 					
@@ -343,6 +345,7 @@ namespace powerAuthTests
 					ccstAssertTrue(s1.hasPendingActivation());
 					ccstAssertFalse(s1.hasValidActivation());
 					ccstAssertEqual(_activation_id, s1.activationIdentifier());
+					ccstAssertEqual(s1.activationFingerprint(), ACTIVATION_FINGERPRINT);
 					
 					if (break_in_step == 2) {
 						s1.resetSession();
@@ -403,6 +406,7 @@ namespace powerAuthTests
 					ec = s1.completeActivation(lock_keys);
 					ccstAssertEqual(ec, EC_Ok);
 					ccstAssertEqual(s1.activationIdentifier(), _activation_id);
+					ccstAssertEqual(s1.activationFingerprint(), ACTIVATION_FINGERPRINT);
 					ccstAssertTrue(s1.hasValidSetup());
 					ccstAssertFalse(s1.canStartActivation());
 					ccstAssertFalse(s1.hasPendingActivation());

--- a/src/PowerAuthTests/pa2SessionTests.cpp
+++ b/src/PowerAuthTests/pa2SessionTests.cpp
@@ -261,13 +261,15 @@ namespace powerAuthTests
 					ccstAssertFalse(s1.canStartActivation());
 					ccstAssertTrue(s1.hasPendingActivation());
 					ccstAssertFalse(s1.hasValidActivation());
-
+					ccstAssertTrue(s1.activationIdentifier().empty());
+					
 					if (break_in_step == 1) {
 						s1.resetSession();
 						ccstAssertTrue(s1.hasValidSetup());
 						ccstAssertTrue(s1.canStartActivation());
 						ccstAssertFalse(s1.hasPendingActivation());
 						ccstAssertFalse(s1.hasValidActivation());
+						ccstAssertTrue(s1.activationIdentifier().empty());
 						continue;
 					}
 					
@@ -340,6 +342,7 @@ namespace powerAuthTests
 					ccstAssertFalse(s1.canStartActivation());
 					ccstAssertTrue(s1.hasPendingActivation());
 					ccstAssertFalse(s1.hasValidActivation());
+					ccstAssertEqual(_activation_id, s1.activationIdentifier());
 					
 					if (break_in_step == 2) {
 						s1.resetSession();


### PR DESCRIPTION
- iOS Fixed tests running in "PA2_Release"