### PR TITLE
Android: Fix #332: Support for asymmetric biometric key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ In order to connect to the [PowerAuth](https://www.wultra.com/product/powerauth-
 
 If you need to upgrade PowerAuth Mobile SDK to a newer version, you can check following migration guides:
 
+- [Migration from version `1.4.x` to `1.5.x`](docs/Migration-from-1.4-to-1.5.md)
 - [Migration from version `1.3.x` to `1.4.x`](docs/Migration-from-1.3-to-1.4.md)
 - [Migration from version `1.2.x` to `1.3.x`](docs/Migration-from-1.2-to-1.3.md)
 - [Migration from version `1.1.x` to `1.2.x`](docs/Migration-from-1.1-to-1.2.md)
@@ -24,11 +25,12 @@ If you need to upgrade PowerAuth Mobile SDK to a newer version, you can check fo
 
 | Mobile SDK | Protocol | PowerAuth Server    | Support Status                    |
 |------------|----------|---------------------|-----------------------------------|
-| `1.4.x`    | `V3.1`   | `0.24+`             | Fully supported                   |
-| `1.3.x`    | `V3.1`   | `0.23+`             | Security & Functionality bugfixes |
+| `1.5.x`    | `V3.1`   | `0.24+`             | Fully supported                   |
+| `1.4.x`    | `V3.1`   | `0.24+`             | Security & Functionality bugfixes |
+| `1.3.x`    | `V3.1`   | `0.23+`             | Security bugfixes                 |
 | `1.2.x`    | `V3.0`   | `0.22+`<sup>1</sup> | Security bugfixes                 |
 | `1.1.x`    | `V3.0`   | `0.21+`             | Security bugfixes                 |
-| `0.20.x`   | `V2.1`   | `0.18+`             | Security bugfixes                 |
+| `0.20.x`   | `V2.1`   | `0.18+`             | Not supported                     |
 
 > Notes
 > 1. If [Recovery Codes](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) feature is not used, then you can 

--- a/docs/Migration-from-1.3-to-1.4.md
+++ b/docs/Migration-from-1.3-to-1.4.md
@@ -30,6 +30,14 @@ PowerAuth Mobile SDK in version `1.4.0` introduces support for an [additional ac
   - If you use higher levels of proteciton than `KeychainProtection.NONE`, then your application may use `KeychainFactory.getKeychainProtectionSupportedOnDevice()` to determine whether the device supports enough level of protection. You can display an error message to the user, if the application cannot be used on the device.
   - Various `PowerAuthKeychainConfiguration` class constructors are no longer available. You have to use `PowerAuthKeychainConfiguration.Builder()` to construct a custom keychain configuration.
 
+- _Version 1.4.4+:_ The `IBiometricAuthenticationCallback` interface has slightly changed:
+  - `void onBiometricDialogSuccess(@NonNull byte[] biometricKeyEncrypted)` is now `void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData)`.
+  - You can call `biometricKeyData.getDerivedData()` to get data equivalent to previous `byte[] biometricKeyEncrypted`.
+
+- _Version 1.4.4+:_ `PowerAuthKeychainConfiguration.Builder` has new option `authenticateOnBiometricKeySetup(boolean)` to tell SDK that biometric authentication is not required for the biometric key setup.
+  - Altering this option will cause that RSA keypair instead of AES key is stored to Android KeyStore.
+  - Previously created keys are not altered, so biometric factors configured with older SDKs works as before.
+
 ## iOS
 
 ### API changes
@@ -46,3 +54,7 @@ PowerAuth Mobile SDK in version `1.4.0` introduces support for an [additional ac
   - The `PA2SupportedBiometricAuthentication` enumeration is no longer available. Use `PA2BiometricAuthenticationType` as a replacement.
   - The `PA2Keychain.addValue(Data, forKey: String, useBiometry: Bool)` method is no longer available. Use `addValue(Data, forKey: String, access: PA2KeychainItemAccess)` as a replacement.
   - The `PA2Keychain.addValue(Data, forKey: String, useBiometry: Bool, completion:)` method is no longer available. Use `addValue(Data, forKey: String, access: PA2KeychainItemAccess, completion:)` as a replacement.
+
+- _Version 1.4.4+:_ Added support for `tvOS` and `macCatalyst` platforms. This change has the following implications to SDK integration:
+  - CocoaPods tool version `1.10+` is required.
+  - CocoaPods integration now uses precompiled `XCFrameworks` as binary artifacts, so be careful in case that your SDK integration has whole `Pods` folder added to the git source control. 

--- a/docs/Migration-from-1.3-to-1.4.md
+++ b/docs/Migration-from-1.3-to-1.4.md
@@ -30,14 +30,6 @@ PowerAuth Mobile SDK in version `1.4.0` introduces support for an [additional ac
   - If you use higher levels of proteciton than `KeychainProtection.NONE`, then your application may use `KeychainFactory.getKeychainProtectionSupportedOnDevice()` to determine whether the device supports enough level of protection. You can display an error message to the user, if the application cannot be used on the device.
   - Various `PowerAuthKeychainConfiguration` class constructors are no longer available. You have to use `PowerAuthKeychainConfiguration.Builder()` to construct a custom keychain configuration.
 
-- _Version 1.4.4+:_ The `IBiometricAuthenticationCallback` interface has slightly changed:
-  - `void onBiometricDialogSuccess(@NonNull byte[] biometricKeyEncrypted)` is now `void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData)`.
-  - You can call `biometricKeyData.getDerivedData()` to get data equivalent to previous `byte[] biometricKeyEncrypted`.
-
-- _Version 1.4.4+:_ `PowerAuthKeychainConfiguration.Builder` has new option `authenticateOnBiometricKeySetup(boolean)` to tell SDK that biometric authentication is not required for the biometric key setup.
-  - Altering this option will cause that RSA keypair instead of AES key is stored to Android KeyStore.
-  - Previously created keys are not altered, so biometric factors configured with older SDKs works as before.
-
 ## iOS
 
 ### API changes
@@ -54,7 +46,3 @@ PowerAuth Mobile SDK in version `1.4.0` introduces support for an [additional ac
   - The `PA2SupportedBiometricAuthentication` enumeration is no longer available. Use `PA2BiometricAuthenticationType` as a replacement.
   - The `PA2Keychain.addValue(Data, forKey: String, useBiometry: Bool)` method is no longer available. Use `addValue(Data, forKey: String, access: PA2KeychainItemAccess)` as a replacement.
   - The `PA2Keychain.addValue(Data, forKey: String, useBiometry: Bool, completion:)` method is no longer available. Use `addValue(Data, forKey: String, access: PA2KeychainItemAccess, completion:)` as a replacement.
-
-- _Version 1.4.4+:_ Added support for `tvOS` and `macCatalyst` platforms. This change has the following implications to SDK integration:
-  - CocoaPods tool version `1.10+` is required.
-  - CocoaPods integration now uses precompiled `XCFrameworks` as binary artifacts, so be careful in case that your SDK integration has whole `Pods` folder added to the git source control. 

--- a/docs/Migration-from-1.4-to-1.5.md
+++ b/docs/Migration-from-1.4-to-1.5.md
@@ -17,6 +17,11 @@ PowerAuth Mobile SDK in version `1.5.0` is a maintenance release that brings few
 - The `IBiometricAuthenticationCallback` interface has slightly changed:
   - `void onBiometricDialogSuccess(@NonNull byte[] biometricKeyEncrypted)` is now `void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData)`.
   - You can call `biometricKeyData.getDerivedData()` to get data equivalent to previous `byte[] biometricKeyEncrypted`.
+  
+- The `IAddBiometryFactorListener` interface is now in `io.getlime.security.powerauth.biometry` package.
+  - `onAddBiometryFactorFailed(@NonNull PowerAuthErrorException error)` callback now returns `PowerAuthErrorException` instead of `Throwable`. 
+
+- The `ICommitActivationWithBiometryListener` interface now provides non-null exception in `onBiometricDialogFailed(@NonNull PowerAuthErrorException exception)` callback.
 
 - `PowerAuthKeychainConfiguration.Builder` has new option `authenticateOnBiometricKeySetup(boolean)` to tell SDK that biometric authentication is not required for the biometric key setup.
   - Altering this option to `false` will cause that RSA keypair is created in Android KeyStore instead of AES key.

--- a/docs/Migration-from-1.4-to-1.5.md
+++ b/docs/Migration-from-1.4-to-1.5.md
@@ -1,0 +1,35 @@
+# Migration from 1.4.x to 1.5.x
+
+This guide contains instructions for migration from PowerAuth Mobile SDK version `1.4.x` to version `1.5.x`.
+
+## Introduction
+
+PowerAuth Mobile SDK in version `1.5.0` is a maintenance release that brings few enhancements to Android and adds support for more Apple platforms.
+
+### Compatibility with PowerAuth Server
+
+- This release is fully compatible with PowerAuth Server version `0.24.x` and `1.0`.
+
+## Android
+
+### API changes
+
+- The `IBiometricAuthenticationCallback` interface has slightly changed:
+  - `void onBiometricDialogSuccess(@NonNull byte[] biometricKeyEncrypted)` is now `void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData)`.
+  - You can call `biometricKeyData.getDerivedData()` to get data equivalent to previous `byte[] biometricKeyEncrypted`.
+
+- `PowerAuthKeychainConfiguration.Builder` has new option `authenticateOnBiometricKeySetup(boolean)` to tell SDK that biometric authentication is not required for the biometric key setup.
+  - Altering this option to `false` will cause that RSA keypair is created in Android KeyStore instead of AES key.
+  - Previously created AES keys are not altered, so biometric factors configured with older SDKs works as before.
+
+## iOS
+
+### API changes
+
+- Minimum supported iOS version is now `9.0`
+
+- PowerAuth mobile SDK is now available for `tvOS` and `macCatalyst` platform and fully supports Apple Silicon CPU architectures.
+
+- Support for new platforms has the following implications to SDK integration:
+  - CocoaPods tool version `1.10+` is required.
+  - CocoaPods integration now uses precompiled `XCFrameworks` as binary artifacts, so be careful in case that your application project has whole `Pods` folder added to the git source control. 

--- a/docs/Migration-from-1.4-to-1.5.md
+++ b/docs/Migration-from-1.4-to-1.5.md
@@ -8,7 +8,7 @@ PowerAuth Mobile SDK in version `1.5.0` is a maintenance release that brings few
 
 ### Compatibility with PowerAuth Server
 
-- This release is fully compatible with PowerAuth Server version `0.24.x` and `1.0`.
+- This release is fully compatible with PowerAuth Server version `0.24.x` and `1.0.x`.
 
 ## Android
 

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -885,6 +885,9 @@ PowerAuthSDK powerAuthSDK = new PowerAuthSDK.Builder(configuration)
         .build(getApplicationContext());
 ```
 
+> Note that the RSA key-pair is internally generated for the configuration above. That may take more time on older devices than the default configuration.
+
+
 ### Disable biometric authentication
 
 You can remove biometry related factor data used by biometric authentication support by simply removing the related key locally, using this one-liner:

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -907,8 +907,9 @@ powerAuthSDK.authenticateUsingBiometry(context, fragmentManager, "Sign in", "Use
     }
 
     @Override
-    public void onBiometricDialogSuccess(@NonNull byte[] encryptedBiometryKey) {
+    public void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData) {
         // User authenticated and biometry key was returned
+        byte[] biometryFactorRelatedKey = biometricKeyData.getDerivedData();
     }
 
     @Override

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -122,7 +122,7 @@ By default, PowerAuth mobile SDK encrypts it's local activation data with the sy
 ```java
 try {
     PowerAuthKeychainConfiguration keychainConfig = new PowerAuthKeychainConfiguration.Builder()
-            .minimalRequiredKeychainProtection(KeychainProtection.HARDWARE))
+            .minimalRequiredKeychainProtection(KeychainProtection.HARDWARE)
             .build();
     // Apply keychain configuration
     PowerAuthSDK powerAuthSDK = new PowerAuthSDK.Builder(configuration)
@@ -871,6 +871,18 @@ powerAuthSDK.addBiometryFactor(context, fragmentManager, "Enable Biometric Authe
         // Error occurred, report it to user
     }
 });
+```
+
+By default, PowerAuth SDK asks user to authenticate with the biometric sensor also during the setup procedure (or during the [activation commit](#committing-activation-data)). To alter this behavior, use the following code to change `PowerAuthKeychainConfiguration` provided to `PowerAuthSDK` instance:
+
+```java
+PowerAuthKeychainConfiguration keychainConfig = new PowerAuthKeychainConfiguration.Builder()
+        .authenticateOnBiometricKeySetup(false)
+        .build();
+// Apply keychain configuration
+PowerAuthSDK powerAuthSDK = new PowerAuthSDK.Builder(configuration)
+        .keychainConfiguration(keychainConfig)
+        .build(getApplicationContext());
 ```
 
 ### Disable biometric authentication

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -372,7 +372,7 @@ powerAuthSDK.commitActivation(context, fragmentManager, "Enable Biometric Authen
     }
     
     @Override
-    public void onBiometricDialogFailed(PowerAuthErrorException error) {
+    public void onBiometricDialogFailed(@NonNull PowerAuthErrorException error) {
         // failure, typically as a result of API misuse, or a biometric authentication failure
     }
 });
@@ -867,7 +867,7 @@ powerAuthSDK.addBiometryFactor(context, fragmentManager, "Enable Biometric Authe
     }
 
     @Override
-    public void onAddBiometryFactorFailed(Throwable t) {
+    public void onAddBiometryFactorFailed(@NonNull PowerAuthErrorException error) {
         // Error occurred, report it to user
     }
 });

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -13,11 +13,12 @@ In order to connect to the [PowerAuth](https://www.wultra.com/product/powerauth-
 
 | Mobile SDK | Protocol | PowerAuth Server    | Support Status                    |
 |------------|----------|---------------------|-----------------------------------|
-| `1.4.x`    | `V3.1`   | `0.24+`             | Fully supported                   |
-| `1.3.x`    | `V3.1`   | `0.23+`             | Security & Functionality bugfixes |
+| `1.5.x`    | `V3.1`   | `0.24+`             | Fully supported                   |
+| `1.4.x`    | `V3.1`   | `0.24+`             | Security & Functionality bugfixes |
+| `1.3.x`    | `V3.1`   | `0.23+`             | Security bugfixes                 |
 | `1.2.x`    | `V3.0`   | `0.22+`<sup>1</sup> | Security bugfixes                 |
 | `1.1.x`    | `V3.0`   | `0.21+`             | Security bugfixes                 |
-| `0.20.x`   | `V2.1`   | `0.18+`             | Security bugfixes                 |
+| `0.20.x`   | `V2.1`   | `0.18+`             | Not supported                     |
 
 > Notes
 > 1. If [Recovery Codes](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation-Recovery.md) feature is not used, then you can
@@ -27,6 +28,7 @@ In order to connect to the [PowerAuth](https://www.wultra.com/product/powerauth-
 
 If you need to upgrade PowerAuth Mobile SDK to a newer version, you can check following migration guides:
 
+- [Migration from version `1.4.x` to `1.5.x`](Migration-from-1.4-to-1.5.md)
 - [Migration from version `1.3.x` to `1.4.x`](Migration-from-1.3-to-1.4.md)
 - [Migration from version `1.2.x` to `1.3.x`](Migration-from-1.2-to-1.3.md)
 - [Migration from version `1.1.x` to `1.2.x`](Migration-from-1.1-to-1.2.md)

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfigurationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfigurationBuilderTest.java
@@ -39,6 +39,7 @@ public class PowerAuthKeychainConfigurationBuilderTest {
         assertEquals(KeychainProtection.NONE, configuration.getMinimalRequiredKeychainProtection());
         assertFalse(configuration.isConfirmBiometricAuthentication());
         assertTrue(configuration.isLinkBiometricItemsToCurrentSet());
+        assertTrue(configuration.isAuthenticateOnBiometricKeySetup());
     }
 
     @Test
@@ -51,6 +52,7 @@ public class PowerAuthKeychainConfigurationBuilderTest {
                 .keychainTokenStoreId("keychain.tokens")
                 .keychainBiometryDefaultKey("biometryKey")
                 .minimalRequiredKeychainProtection(KeychainProtection.HARDWARE)
+                .authenticateOnBiometricKeySetup(false)
                 .build();
         assertEquals("keychain.biometry", configuration.getKeychainBiometryId());
         assertEquals("keychain.status", configuration.getKeychainStatusId());
@@ -59,5 +61,6 @@ public class PowerAuthKeychainConfigurationBuilderTest {
         assertEquals(KeychainProtection.HARDWARE, configuration.getMinimalRequiredKeychainProtection());
         assertTrue(configuration.isConfirmBiometricAuthentication());
         assertFalse(configuration.isLinkBiometricItemsToCurrentSet());
+        assertFalse(configuration.isAuthenticateOnBiometricKeySetup());
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -24,8 +24,6 @@ import android.support.annotation.UiThread;
 import android.support.v4.app.FragmentManager;
 import android.util.Pair;
 
-import javax.crypto.SecretKey;
-
 import io.getlime.security.powerauth.biometry.impl.BiometricAuthenticator;
 import io.getlime.security.powerauth.biometry.impl.BiometricErrorDialogFragment;
 import io.getlime.security.powerauth.biometry.impl.BiometricHelper;
@@ -42,7 +40,6 @@ import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.sdk.impl.CancelableTask;
 import io.getlime.security.powerauth.sdk.impl.DefaultCallbackDispatcher;
 import io.getlime.security.powerauth.sdk.impl.DummyCancelable;
-import io.getlime.security.powerauth.sdk.impl.ICallbackDispatcher;
 import io.getlime.security.powerauth.system.PA2Log;
 
 /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -134,7 +134,7 @@ public class BiometricAuthenticationRequest {
         private CharSequence subtitle;
         private CharSequence description;
 
-        private boolean forceGenerateNewKey;
+        private boolean forceGenerateNewKey = false;
         private boolean invalidateByBiometricEnrollment = true;
         private boolean userConfirmationRequired = false;
         private boolean useSymmetricCipher = false;
@@ -244,12 +244,12 @@ public class BiometricAuthenticationRequest {
         }
 
         /**
-         * @param forceGenerateNewKey If true then the new biometric key will be generated as a
-         *                            part of the process.
+         * @param forceGenerateNewKey             If true then the new biometric key will be generated as a
+         *                                        part of the process.
          * @param invalidateByBiometricEnrollment Sets whether the new key should be invalidated on
          *                                        biometric enrollment.
-         * @param useSymmetricCipher If true then symmetric cipher will be used to biometric factor key
-         *                           protection.
+         * @param useSymmetricCipher              If true then symmetric cipher will be used to biometric
+         *                                        factor key protection.
          * @return This value will never be {@code null}.
          */
         public Builder setForceGenerateNewKey(boolean forceGenerateNewKey, boolean invalidateByBiometricEnrollment, boolean useSymmetricCipher) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -110,7 +110,9 @@ public class BiometricAuthenticationRequest {
     }
 
     /**
-     * @return Application provided key which will be protected by the biometric key.
+     * @return Application provided key which will be protected by the biometric key. The content
+     * depends on whether the key is being encrypted (for key setup procedure) or decrypted (for
+     * a signature calculation).
      */
     public @NonNull byte[] getRawKeyData() {
         return rawKeyData;
@@ -137,7 +139,7 @@ public class BiometricAuthenticationRequest {
         private boolean forceGenerateNewKey = false;
         private boolean invalidateByBiometricEnrollment = true;
         private boolean userConfirmationRequired = false;
-        private boolean useSymmetricCipher = false;
+        private boolean useSymmetricCipher = true;
         private byte[] rawKeyData;
         private IBiometricKeyEncryptor biometricKeyEncryptor;
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -35,7 +35,9 @@ public class BiometricAuthenticationRequest {
     private final boolean forceGenerateNewKey;
     private final boolean invalidateByBiometricEnrollment;
     private final boolean userConfirmationRequired;
-    private final @NonNull byte[] keyToProtect;
+    private final boolean useSymmetricCipher;
+    private final @NonNull byte[] rawKeyData;
+    private final @NonNull IBiometricKeyEncryptor biometricKeyEncryptor;
 
     private BiometricAuthenticationRequest(
             @NonNull CharSequence title,
@@ -44,14 +46,18 @@ public class BiometricAuthenticationRequest {
             boolean forceGenerateNewKey,
             boolean invalidateByBiometricEnrollment,
             boolean userConfirmationRequired,
-            @NonNull byte[] keyToProtect) {
+            boolean useSymmetricCipher,
+            @NonNull byte[] rawKeyData,
+            @NonNull IBiometricKeyEncryptor biometricKeyEncryptor) {
         this.title = title;
         this.subtitle = subtitle;
         this.description = description;
         this.forceGenerateNewKey = forceGenerateNewKey;
         this.invalidateByBiometricEnrollment = invalidateByBiometricEnrollment;
         this.userConfirmationRequired = userConfirmationRequired;
-        this.keyToProtect = Arrays.copyOf(keyToProtect, keyToProtect.length);
+        this.useSymmetricCipher = useSymmetricCipher;
+        this.rawKeyData = Arrays.copyOf(rawKeyData, rawKeyData.length);
+        this.biometricKeyEncryptor = biometricKeyEncryptor;
     }
 
     /**
@@ -97,10 +103,24 @@ public class BiometricAuthenticationRequest {
     }
 
     /**
+     * @return {@code true} in case that symmetric cipher should be used for biometric key protection.
+     */
+    public boolean isUseSymmetricCipher() {
+        return useSymmetricCipher;
+    }
+
+    /**
      * @return Application provided key which will be protected by the biometric key.
      */
-    public @NonNull byte[] getKeyToProtect() {
-        return keyToProtect;
+    public @NonNull byte[] getRawKeyData() {
+        return rawKeyData;
+    }
+
+    /**
+     * @return Object that encrypt or decrypt raw key data.
+     */
+    public @NonNull IBiometricKeyEncryptor getBiometricKeyEncryptor() {
+        return biometricKeyEncryptor;
     }
 
     /**
@@ -117,7 +137,9 @@ public class BiometricAuthenticationRequest {
         private boolean forceGenerateNewKey;
         private boolean invalidateByBiometricEnrollment = true;
         private boolean userConfirmationRequired = false;
-        private byte[] keyToProtect;
+        private boolean useSymmetricCipher = false;
+        private byte[] rawKeyData;
+        private IBiometricKeyEncryptor biometricKeyEncryptor;
 
         /**
          * Creates a builder for a biometric dialog.
@@ -138,11 +160,14 @@ public class BiometricAuthenticationRequest {
             if (TextUtils.isEmpty(title) || TextUtils.isEmpty(description)) {
                 throw new IllegalArgumentException("Title and description is required.");
             }
-            if (keyToProtect == null) {
-                throw new IllegalArgumentException("KeyToProtect is required.");
+            if (rawKeyData == null) {
+                throw new IllegalArgumentException("RawKeyData is required.");
             }
-            if (keyToProtect.length < 16) {
-                throw new IllegalArgumentException("KeyToProtect length is insufficient.");
+            if (rawKeyData.length < 16) {
+                throw new IllegalArgumentException("RawKeyData length is insufficient.");
+            }
+            if (biometricKeyEncryptor == null) {
+                throw new IllegalArgumentException("BiometricKeyEncryptor is required.");
             }
             return new BiometricAuthenticationRequest(
                     title,
@@ -151,7 +176,9 @@ public class BiometricAuthenticationRequest {
                     forceGenerateNewKey,
                     invalidateByBiometricEnrollment,
                     userConfirmationRequired,
-                    keyToProtect);
+                    useSymmetricCipher,
+                    rawKeyData,
+                    biometricKeyEncryptor);
         }
 
         /**
@@ -220,12 +247,15 @@ public class BiometricAuthenticationRequest {
          * @param forceGenerateNewKey If true then the new biometric key will be generated as a
          *                            part of the process.
          * @param invalidateByBiometricEnrollment Sets whether the new key should be invalidated on
-         *                                       biometric enrollment.
+         *                                        biometric enrollment.
+         * @param useSymmetricCipher If true then symmetric cipher will be used to biometric factor key
+         *                           protection.
          * @return This value will never be {@code null}.
          */
-        public Builder setForceGenerateNewKey(boolean forceGenerateNewKey, boolean invalidateByBiometricEnrollment) {
+        public Builder setForceGenerateNewKey(boolean forceGenerateNewKey, boolean invalidateByBiometricEnrollment, boolean useSymmetricCipher) {
             this.forceGenerateNewKey = forceGenerateNewKey;
             this.invalidateByBiometricEnrollment = invalidateByBiometricEnrollment;
+            this.useSymmetricCipher = useSymmetricCipher;
             return this;
         }
 
@@ -245,13 +275,15 @@ public class BiometricAuthenticationRequest {
         }
 
         /**
-         * Required: Sets sequence of bytes as key, which will be encrypted by the biometry.
+         * Required: Sets sequence of bytes that will be encrypted or decrypted with using biometric authentication.
          *
-         * @param keyBytes Array of bytes containing a key, which will be encrypted by the biometric key.
+         * @param keyData Array of bytes containing a key, which will be encrypted by the biometric key.
+         * @param biometricKeyEncryptor Object that perform biometric key encryption and decryption.
          * @return This value will never be {@code null}.
          */
-        public Builder setKeyToProtect(@NonNull byte[] keyBytes) {
-            this.keyToProtect = keyBytes;
+        public Builder setRawKeyData(@NonNull byte[] keyData, @NonNull IBiometricKeyEncryptor biometricKeyEncryptor) {
+            this.rawKeyData = keyData;
+            this.biometricKeyEncryptor = biometricKeyEncryptor;
             return this;
         }
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.biometry;
+
+import android.support.annotation.NonNull;
+
+public class BiometricKeyData {
+
+    private final @NonNull byte[] dataToSave;
+    private final @NonNull byte[] derivedData;
+
+    public BiometricKeyData(@NonNull byte[] dataToSave, @NonNull byte[] derivedData) {
+        this.dataToSave = dataToSave;
+        this.derivedData = derivedData;
+    }
+
+    public @NonNull byte[] getDataToSave() {
+        return dataToSave;
+    }
+
+    public @NonNull byte[] getDerivedData() {
+        return derivedData;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
@@ -18,21 +18,47 @@ package io.getlime.security.powerauth.biometry;
 
 import android.support.annotation.NonNull;
 
+/**
+ * The {@code BiometricKeyData} class contains result from the biometric authentication in case that
+ * authentication succeeded.
+ */
 public class BiometricKeyData {
 
     private final @NonNull byte[] dataToSave;
     private final @NonNull byte[] derivedData;
+    private final boolean newKey;
 
-    public BiometricKeyData(@NonNull byte[] dataToSave, @NonNull byte[] derivedData) {
+    /**
+     * Construct object with data to save, derived key and flag that this is a new key generated.
+     *
+     * @param dataToSave Data that should be stored to the persistent storage in case that this is a new key.
+     * @param derivedData Data derived from raw key bytes provided in biometric authentication request.
+     * @param isNewKey Is {@code true} in case that this is a new key generated.
+     */
+    public BiometricKeyData(@NonNull byte[] dataToSave, @NonNull byte[] derivedData, boolean isNewKey) {
         this.dataToSave = dataToSave;
         this.derivedData = derivedData;
+        this.newKey = isNewKey;
     }
 
+    /**
+     * @return Data that should be stored to the persistent storage in case that this is a new key.
+     */
     public @NonNull byte[] getDataToSave() {
         return dataToSave;
     }
 
+    /**
+     * @return Data derived from raw key bytes provided in biometric authentication request.
+     */
     public @NonNull byte[] getDerivedData() {
         return derivedData;
+    }
+
+    /**
+     * @return Is {@code true} in case that this is a new key generated.
+     */
+    public boolean isNewKey() {
+        return newKey;
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAddBiometryFactorListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAddBiometryFactorListener.java
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package io.getlime.security.powerauth.networking.response;
+package io.getlime.security.powerauth.biometry;
 
 import android.support.annotation.MainThread;
+import android.support.annotation.NonNull;
+
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 
 /**
  * Listener for adding biometry factor.
@@ -32,8 +35,8 @@ public interface IAddBiometryFactorListener {
     /**
      * Called when biometry factor addition fails.
      *
-     * @param t error that occurred during the biometry factor addition.
+     * @param error Error that occurred during the biometry factor addition.
      */
     @MainThread
-    void onAddBiometryFactorFailed(Throwable t);
+    void onAddBiometryFactorFailed(@NonNull PowerAuthErrorException error);
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricAuthenticationCallback.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricAuthenticationCallback.java
@@ -40,11 +40,11 @@ public interface IBiometricAuthenticationCallback {
     /**
      * Biometric authentication succeeded.
      *
-     * @param biometricKeyEncrypted Biometric key encrypted with biometric protected key from
-     *                              Keystore - use this key as a value for biometric authentication.
+     * @param biometricKeyData Object containing derived biometric key and key data that must be saved
+     *                         to persistent storage.
      */
     @UiThread
-    void onBiometricDialogSuccess(@NonNull byte[] biometricKeyEncrypted);
+    void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData);
 
     /**
      * Biometric authentication failed with the error.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricAuthenticationCallback.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricAuthenticationCallback.java
@@ -40,8 +40,8 @@ public interface IBiometricAuthenticationCallback {
     /**
      * Biometric authentication succeeded.
      *
-     * @param biometricKeyData Object containing derived biometric key and key data that must be saved
-     *                         to persistent storage.
+     * @param biometricKeyData {@link BiometricKeyData} object with derived key and data that should
+     *                         be stored to the persistent storage.
      */
     @UiThread
     void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.biometry;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
+
+import javax.crypto.Cipher;
+
+/**
+ * TODO: missing doc
+ */
+@RequiresApi(api = Build.VERSION_CODES.M)
+public interface IBiometricKeyEncryptor {
+
+    /**
+     * @return {@code true} if biometric authentication is required in {@link #decryptBiometricKey(byte[])} method.
+     */
+    boolean isAuthenticationRequiredOnEncryption();
+
+    /**
+     * Initialize {@link Cipher} and keep it internally for later key encryption or decryption. The method can
+     * be used only for once, during the encryptor's lifecycle.
+     *
+     * @param encryptMode Tells whether object will be later used for key encryption or decryption.
+     *
+     * @return Instance of {@link Cipher} object.
+     */
+    @Nullable Cipher initializeCipher(boolean encryptMode);
+
+    /**
+     * Encrypt biometric key and return object that contains encrypted key and data to store to permanent storage.
+     * The values may differ in case that encryption and decryption actually implement KDF, so the source sequence
+     * of bytes must be saved.
+     * <p>
+     * The method can be used only for once during the encryptor's lifecycle.
+     *
+     * @param key Biometric KEK to encrypt.
+     * @return Pair of byte arrays, where first contains data to store to the permanent storage and
+     *         second contains encrypted key.
+     */
+    @Nullable
+    BiometricKeyData encryptBiometricKey(@NonNull byte[] key);
+
+    /**
+     * Decrypt biometric key from previously stored value.
+     * <p>
+     * The method can be used only for once during the encryptor's lifecycle.
+     *
+     * @param encryptedKey Previously stored encrypted key.
+     * @return Decrypted key.
+     */
+    @Nullable
+    BiometricKeyData decryptBiometricKey(@NonNull byte[] encryptedKey);
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
@@ -29,7 +29,7 @@ import javax.crypto.Cipher;
  * the encryption key that is protected with the biometric authentication.
  * <p>
  * Instance of this object can be typically used only for once, per encryption or decryption task.
- * Calling methods from this interface for multiple times produce an illegal argument exception.
+ * Calling methods from this interface for multiple times produce {@code IllegalStateException}.
  */
 @RequiresApi(api = Build.VERSION_CODES.M)
 public interface IBiometricKeyEncryptor {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
@@ -24,13 +24,20 @@ import android.support.annotation.RequiresApi;
 import javax.crypto.Cipher;
 
 /**
- * TODO: missing doc
+ * The {@code IBiometricKeyEncryptor} provides encryption and decryption of KEK that protects
+ * PowerAuth biometric factor. The underlying implementation use Android KeyStore to store
+ * the encryption key that is protected with the biometric authentication.
+ * <p>
+ * Instance of this object can be typically used only for once, per encryption or decryption task.
+ * Calling methods from this interface for multiple times produce an illegal argument exception.
  */
 @RequiresApi(api = Build.VERSION_CODES.M)
 public interface IBiometricKeyEncryptor {
 
     /**
-     * @return {@code true} if biometric authentication is required in {@link #decryptBiometricKey(byte[])} method.
+     * @return {@code true} if biometric authentication is required in {@link #encryptBiometricKey(byte[])} method.
+     *         If {@code false} is returned, then typically the setup of biometric factor doesn't require
+     *         biometric authentication.
      */
     boolean isAuthenticationRequiredOnEncryption();
 
@@ -40,9 +47,10 @@ public interface IBiometricKeyEncryptor {
      *
      * @param encryptMode Tells whether object will be later used for key encryption or decryption.
      *
-     * @return Instance of {@link Cipher} object.
+     * @return Instance of {@link Cipher} object or {@code null} in case of failure.
      */
-    @Nullable Cipher initializeCipher(boolean encryptMode);
+    @Nullable
+    Cipher initializeCipher(boolean encryptMode);
 
     /**
      * Encrypt biometric key and return object that contains encrypted key and data to store to permanent storage.
@@ -52,8 +60,7 @@ public interface IBiometricKeyEncryptor {
      * The method can be used only for once during the encryptor's lifecycle.
      *
      * @param key Biometric KEK to encrypt.
-     * @return Pair of byte arrays, where first contains data to store to the permanent storage and
-     *         second contains encrypted key.
+     * @return {@link BiometricKeyData} with key derivation and data to store to persistent storage.
      */
     @Nullable
     BiometricKeyData encryptBiometricKey(@NonNull byte[] key);
@@ -64,7 +71,7 @@ public interface IBiometricKeyEncryptor {
      * The method can be used only for once during the encryptor's lifecycle.
      *
      * @param encryptedKey Previously stored encrypted key.
-     * @return Decrypted key.
+     * @return {@link BiometricKeyData} with restored key derivation.
      */
     @Nullable
     BiometricKeyData decryptBiometricKey(@NonNull byte[] encryptedKey);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeyEncryptor.java
@@ -16,10 +16,8 @@
 
 package io.getlime.security.powerauth.biometry;
 
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 
 import javax.crypto.Cipher;
 
@@ -31,7 +29,6 @@ import javax.crypto.Cipher;
  * Instance of this object can be typically used only for once, per encryption or decryption task.
  * Calling methods from this interface for multiple times produce {@code IllegalStateException}.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public interface IBiometricKeyEncryptor {
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
@@ -19,21 +19,23 @@ package io.getlime.security.powerauth.biometry;
 import android.support.annotation.Nullable;
 
 /**
- * Interface representing a Keystore used to store biometry related key.
+ * Interface wrapping a key stored in Android KeyStore and providing {@link IBiometricKeyEncryptor}
+ * that can encrypt and decrypt biometry related keys for PowerAuth protocol.
  */
 public interface IBiometricKeystore {
 
     /**
      * Check if the Keystore is ready.
      *
-     * @return True if Keystore is ready, false otherwise.
+     * @return {@code true} if KeyStore is ready, false otherwise.
      */
     boolean isKeystoreReady();
 
     /**
-     * Check if a key for biometric key encryptor is present in Keystore
+     * Check if a key for biometric key encryptor is present in Keystore and {@link IBiometricKeyEncryptor}
+     * can be acquired.
      *
-     * @return True in case a key for biometric key encryptor is present, false otherwise.
+     * @return {@code true} in case a key for biometric key encryptor is present, false otherwise.
      *         Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
      */
     boolean containsBiometricKeyEncryptor();
@@ -58,7 +60,8 @@ public interface IBiometricKeystore {
     void removeBiometricKeyEncryptor();
 
     /**
-     * @return Default biometry related key, stored in KeyStore or null if no such key is stored.
+     * @return {@link IBiometricKeyEncryptor} constructed with key stored in KeyStore or {@code null}
+     *         if no such key is stored.
      */
     @Nullable
     IBiometricKeyEncryptor getBiometricKeyEncryptor();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
@@ -18,8 +18,6 @@ package io.getlime.security.powerauth.biometry;
 
 import android.support.annotation.Nullable;
 
-import javax.crypto.SecretKey;
-
 /**
  * Interface representing a Keystore used to store biometry related key.
  */
@@ -33,32 +31,35 @@ public interface IBiometricKeystore {
     boolean isKeystoreReady();
 
     /**
-     * Check if a default key is present in Keystore
+     * Check if a key for biometric key encryptor is present in Keystore
      *
-     * @return True in case a default key is present, false otherwise. Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
+     * @return True in case a key for biometric key encryptor is present, false otherwise.
+     *         Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
      */
-    boolean containsDefaultKey();
+    boolean containsBiometricKeyEncryptor();
 
     /**
-     * Generate a new biometry related Keystore key with default key name.
+     * Generate a new biometry related Keystore key and return object that provide KEK encryption and decryption.
      *
-     * The key that is created during this process is used to encrypt key stored in shared preferences,
+     * The key that is created during this process is used to encrypt KEK stored in shared preferences,
      * in order to derive key used for biometric authentication.
      *
      * @param invalidateByBiometricEnrollment Sets whether the new key should be invalidated on biometric enrollment.
-     * @return New generated {@link SecretKey} key or {@code null} in case of failure.
+     * @param useSymmetricKey Sets whether symmetric key should be created.
+     *
+     * @return New generated {@link IBiometricKeyEncryptor} key or {@code null} in case of failure.
      */
-    @Nullable SecretKey generateDefaultKey(boolean invalidateByBiometricEnrollment);
+    @Nullable
+    IBiometricKeyEncryptor createBiometricKeyEncryptor(boolean invalidateByBiometricEnrollment, boolean useSymmetricKey);
 
     /**
      * Removes an encryption key from Keystore.
-     *
-     * @return True in case key was removed, false otherwise.
      */
-    boolean removeDefaultKey();
+    void removeBiometricKeyEncryptor();
 
     /**
      * @return Default biometry related key, stored in KeyStore or null if no such key is stored.
      */
-    @Nullable SecretKey getDefaultKey();
+    @Nullable
+    IBiometricKeyEncryptor getBiometricKeyEncryptor();
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/ICommitActivationWithBiometryListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/ICommitActivationWithBiometryListener.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.biometry;
 
+import android.support.annotation.NonNull;
+
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 
 /**
@@ -38,6 +40,6 @@ public interface ICommitActivationWithBiometryListener {
      *
      * @param error error that occurred during the activation commit.
      */
-    void onBiometricDialogFailed(PowerAuthErrorException error);
+    void onBiometricDialogFailed(@NonNull PowerAuthErrorException error);
 
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricHelper.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricHelper.java
@@ -18,31 +18,15 @@ package io.getlime.security.powerauth.biometry.impl;
 
 import android.content.Context;
 import android.os.Build;
-import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.support.annotation.StringRes;
 import android.util.Pair;
-
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.AlgorithmParameterSpec;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
 
 import io.getlime.security.powerauth.R;
 import io.getlime.security.powerauth.biometry.BiometricDialogResources;
 import io.getlime.security.powerauth.biometry.BiometricStatus;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
-import io.getlime.security.powerauth.system.PA2Log;
 
 /**
  * The {@code BiometricHelper} class provides helper methods for PowerAuth Mobile SDK. The class
@@ -99,42 +83,6 @@ public class BiometricHelper {
             errorDescription = resources.strings.errorFingerprintDisabledDescription;
         }
         return Pair.create(errorTitle, errorDescription);
-    }
-
-    /**
-     * Create AES/CBC with PKCS7 padding cipher with given secret key.
-     *
-     * @param key Key to be used for encryption and decryption.
-     * @return {@link Cipher} object or null in case of error.
-     */
-    @RequiresApi(api = Build.VERSION_CODES.M)
-    public static @Nullable Cipher createAesCipher(@NonNull SecretKey key) {
-        try {
-            final Cipher cipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_CBC + "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7);
-            final byte[] zero_iv = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-            AlgorithmParameterSpec algorithmSpec = new IvParameterSpec(zero_iv);
-            cipher.init(Cipher.ENCRYPT_MODE, key, algorithmSpec);
-            return cipher;
-        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException | NoSuchAlgorithmException | InvalidKeyException e) {
-            PA2Log.e("BiometricHelper.createAesCipher failed: " + e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * Encrypt provided key bytes with using cipher.
-     *
-     * @param keyToProtect Bytes containing key to be protected with the cipher.
-     * @param cipher Cipher for the key encryption.
-     * @return Encrypted bytes, or {@code null} in case of encryption error.
-     */
-    public static @Nullable byte[] protectKeyWithCipher(@NonNull byte[] keyToProtect, @NonNull Cipher cipher) {
-        try {
-            return cipher.doFinal(keyToProtect);
-        } catch (IllegalBlockSizeException | BadPaddingException e) {
-            PA2Log.e("BiometricHelper.protectKeyWithCipher failed: " + e.getMessage());
-            return null;
-        }
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -24,7 +24,6 @@ import android.support.annotation.Nullable;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.ProviderException;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -121,9 +121,11 @@ public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
     @Nullable
     @Override
     public BiometricKeyData decryptBiometricKey(@NonNull byte[] encryptedKey) {
+        // Note that "encryptedKey" is actually the same key as was provided to "encryptBiometricKey"
+        // method. This is due to fact, that we use AES as KDF.
         final byte[] derivedKey = aesKdf(encryptedKey, false);
-        // We use AES as KDF, so we must return the provided key back to the application
-        // to save it to the persistent storage, to be able to perform the same KDF in decryption.
+        // It's not required to store "dataToSave" after the decryption. We return the same data
+        // just for convenience.
         return derivedKey != null ? new BiometricKeyData(encryptedKey, derivedKey, false) : null;
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -155,7 +155,7 @@ public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
                 throw new IllegalStateException("Encryptor is not configured for " + (encryptMode ? "encryption" : "decryption"));
             }
             if (encryptorIsUsed) {
-                throw new IllegalStateException("Encryptor cannot be used for twice");
+                throw new IllegalStateException("Encryptor cannot be used for the second time");
             }
             encryptorIsUsed = true;
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -52,7 +52,13 @@ import io.getlime.security.powerauth.system.PA2Log;
 @RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
 
+    /**
+     * Symmetric AES key.
+     */
     private final @NonNull SecretKey key;
+    /**
+     * Symmetric AES cipher
+     */
     private @Nullable Cipher cipher;
     /**
      * If true, then internal cipher is already initialized.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -21,6 +21,7 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -48,6 +49,7 @@ import io.getlime.security.powerauth.system.PA2Log;
  * <p>
  * The cipher configuration is compatible with previous versions of PowerAuth SDK (1.4.3 and older).
  */
+@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
 
     private final @NonNull SecretKey key;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.biometry.impl;
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.ProviderException;
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+
+import io.getlime.security.powerauth.biometry.BiometricKeyData;
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
+import io.getlime.security.powerauth.system.PA2Log;
+
+public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
+
+    private final @NonNull Key key;
+    private @Nullable Cipher cipher;
+    private boolean cipherIsInitialized;
+    private boolean encryptorIsUsed;
+    private boolean encryptMode;
+
+    private static final String AES_CIPHER = "AES/CBC/PKCS7Padding";
+
+    public BiometricKeyEncryptorAes(@NonNull Key key) {
+        this.key = key;
+    }
+
+    @Override
+    public boolean isAuthenticationRequiredOnEncryption() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Cipher initializeCipher(boolean encryptMode) {
+        try {
+            if (cipherIsInitialized) {
+                throw new IllegalStateException("Cipher is already initialized");
+            }
+            cipher = Cipher.getInstance(AES_CIPHER);
+            if (cipher != null) {
+                final byte[] zero_iv = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+                AlgorithmParameterSpec algorithmSpec = new IvParameterSpec(zero_iv);
+                cipher.init(Cipher.ENCRYPT_MODE, key, algorithmSpec);
+                this.encryptMode = encryptMode;
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+            PA2Log.e("BiometricKeyEncryptorAes.initializeCipher failed: " + e.getMessage());
+            this.cipher = null;
+        } finally {
+            this.cipherIsInitialized = true;
+        }
+        return cipher;
+    }
+
+    @Nullable
+    @Override
+    public BiometricKeyData encryptBiometricKey(@NonNull byte[] key) {
+        final byte[] derivedKey = aesKdf(key, true);
+        // TODO: explain why we're returning different data.
+        return derivedKey != null ? new BiometricKeyData(key, derivedKey) : null;
+    }
+
+    @Nullable
+    @Override
+    public BiometricKeyData decryptBiometricKey(@NonNull byte[] encryptedKey) {
+        final byte[] derivedKey = aesKdf(encryptedKey, false);
+        // TODO: explain why we're returning different data.
+        return derivedKey != null ? new BiometricKeyData(encryptedKey, derivedKey) : null;
+    }
+
+    @Nullable
+    private byte[] aesKdf(@NonNull byte[] keyToDerive, boolean encryptMode) {
+        try {
+            // State checks
+            if (cipher == null) {
+                throw new IllegalStateException("Cipher is not initialized");
+            }
+            if (this.encryptMode != encryptMode) {
+                throw new IllegalStateException("Encryptor is not configured for " + (encryptMode ? "encryption" : "decryption"));
+            }
+            if (encryptorIsUsed) {
+                throw new IllegalStateException("Encryptor cannot be used for twice");
+            }
+            encryptorIsUsed = true;
+
+            // Derive the key
+            return cipher.doFinal(keyToDerive);
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            PA2Log.e("BiometricKeyEncryptorAes.aesKdf failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    public static IBiometricKeyEncryptor createAesEncryptor(@NonNull String providerName, @NonNull String keyName, boolean invalidateByBiometricEnrollment) {
+        try {
+            final KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", providerName);
+            final KeyGenParameterSpec.Builder keySpecBuilder = new KeyGenParameterSpec.Builder(keyName, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                    .setUserAuthenticationRequired(true)
+                    .setRandomizedEncryptionRequired(false)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                keySpecBuilder.setInvalidatedByBiometricEnrollment(invalidateByBiometricEnrollment);
+            }
+            keyGenerator.init(keySpecBuilder.build());
+            final Key key = keyGenerator.generateKey();
+            return new BiometricKeyEncryptorAes(key);
+        } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchProviderException | ProviderException e) {
+            PA2Log.e("BiometricKeyEncryptorAes.createAesEncryptor failed: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -24,7 +24,6 @@ import android.support.annotation.Nullable;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -158,10 +158,10 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
                 throw new IllegalStateException("Cipher is not initialized");
             }
             if (!encryptMode) {
-                throw new IllegalStateException("Encryptor is not configured for encryption.");
+                throw new IllegalStateException("Encryptor is not configured for encryption");
             }
             if (encryptorIsUsed) {
-                throw new IllegalStateException("Encryptor cannot be used for twice");
+                throw new IllegalStateException("Encryptor cannot be used for the second time");
             }
             encryptorIsUsed = true;
 
@@ -189,7 +189,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
                 throw new IllegalStateException("Encryptor is not used for decryption");
             }
             if (encryptorIsUsed) {
-                throw new IllegalStateException("Encryptor cannot be used for twice");
+                throw new IllegalStateException("Encryptor cannot be used for the second time");
             }
             encryptorIsUsed = true;
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.biometry.impl;
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.X509EncodedKeySpec;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+
+import io.getlime.security.powerauth.biometry.BiometricKeyData;
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
+import io.getlime.security.powerauth.system.PA2Log;
+
+public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
+
+    private final @Nullable PublicKey publicKey;
+    private final @Nullable Key privateKey;
+    private @Nullable Cipher cipher;
+    private boolean cipherIsInitialized;
+    private boolean encryptorIsUsed;
+    private boolean encryptMode;
+
+    private static final String RSA_CIPHER = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
+
+    public BiometricKeyEncryptorRsa(@NonNull PublicKey publicKey) {
+        this.publicKey = publicKey;
+        this.privateKey = null;
+    }
+
+    public BiometricKeyEncryptorRsa(@NonNull Key privateKey) {
+        this.publicKey = null;
+        this.privateKey = privateKey;
+    }
+
+    @Override
+    public boolean isAuthenticationRequiredOnEncryption() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Cipher initializeCipher(boolean encryptMode) {
+        try {
+            if (cipherIsInitialized) {
+                throw new IllegalStateException("Cipher is already initialized");
+            }
+            // Get instance of RSA cipher
+            cipher = Cipher.getInstance(RSA_CIPHER);
+            if (cipher != null) {
+                if (encryptMode) {
+                    // Initialize for encryption with public key.
+                    if (publicKey == null) {
+                        throw new IllegalStateException("Initializing cipher for encryption, but public key is missing");
+                    }
+                    // Initialize RSA parameters (OAEP with SHA-256 and MGF1)
+                    final PublicKey unrestrictedPublicKey = KeyFactory.getInstance(publicKey.getAlgorithm()).generatePublic(new X509EncodedKeySpec(publicKey.getEncoded()));
+                    final OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                    // Initialize cipher for data encryption
+                    cipher.init(Cipher.ENCRYPT_MODE, unrestrictedPublicKey, spec);
+                } else {
+                    // Initialize for decryption with private key.
+                    if (privateKey == null) {
+                        throw new IllegalStateException("Initializing cipher for decryption, but private key is missing");
+                    }
+                    // Initialize cipher for data decryption.
+                    cipher.init(Cipher.DECRYPT_MODE, privateKey);
+                }
+                this.encryptMode = encryptMode;
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+            PA2Log.e("BiometricKeyEncryptorRsa.initializeCipher failed: " + e.getMessage());
+            this.cipher = null;
+        } finally {
+            cipherIsInitialized = true;
+        }
+        return cipher;
+    }
+
+    @Nullable
+    @Override
+    public BiometricKeyData encryptBiometricKey(@NonNull byte[] key) {
+        try {
+            // State checks
+            if (cipher == null) {
+                throw new IllegalStateException("Cipher is not initialized");
+            }
+            if (!encryptMode) {
+                throw new IllegalStateException("Encryptor is not configured for encryption.");
+            }
+            if (encryptorIsUsed) {
+                throw new IllegalStateException("Encryptor cannot be used for twice");
+            }
+            encryptorIsUsed = true;
+
+            // Encrypt data
+            final byte[] encryptedBiometricKey = cipher.doFinal(key);
+            // RSA encryptor really needs to store encrypted data. So, we're returned the same
+            // array of bytes in BiometricKeyData object.
+            return new BiometricKeyData(encryptedBiometricKey, encryptedBiometricKey);
+
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            PA2Log.e("BiometricKeyEncryptorRsa.encryptBiometricKey failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    @Override
+    public BiometricKeyData decryptBiometricKey(@NonNull byte[] encryptedKey) {
+        try {
+            // State checks
+            if (cipher == null) {
+                throw new IllegalStateException("Cipher is not initialized");
+            }
+            if (encryptMode) {
+                throw new IllegalStateException("Encryptor is not used for decryption");
+            }
+            if (encryptorIsUsed) {
+                throw new IllegalStateException("Encryptor cannot be used for twice");
+            }
+            encryptorIsUsed = true;
+
+            // Decrypt data
+            final byte[] decryptedKey = cipher.doFinal(encryptedKey);
+            return new BiometricKeyData(encryptedKey, decryptedKey);
+
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            PA2Log.e("BiometricKeyEncryptorRsa.decryptBiometricKey failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    public static IBiometricKeyEncryptor createRsaEncryptor(@NonNull String providerName, @NonNull String keyName, boolean invalidateByBiometricEnrollment) {
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_RSA, providerName);
+            KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(keyName,
+                    KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                    .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+                    .setUserAuthenticationRequired(true);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                builder.setInvalidatedByBiometricEnrollment(invalidateByBiometricEnrollment);
+            }
+            keyPairGenerator.initialize(builder.build());
+            final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            final PublicKey publicKey = keyPair.getPublic();
+            return new BiometricKeyEncryptorRsa(publicKey);
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+            PA2Log.e("BiometricKeyEncryptorRsa.createRsaEncryptor failed: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -21,6 +21,7 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -52,6 +53,7 @@ import io.getlime.security.powerauth.system.PA2Log;
  * is stored in Android KeyStore and the biometric authentication is required only for data
  * decryption.
  */
+@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -122,7 +122,8 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
                     if (publicKey == null) {
                         throw new IllegalStateException("Initializing cipher for encryption, but public key is missing");
                     }
-                    // Initialize RSA parameters (OAEP with SHA-256 and MGF1)
+                    // Initialize RSA parameters (OAEP with SHA-256 and MGF1).
+                    // Note that MGF1 configured with SHA-256 is not supported, so that's why we still use SHA-1.
                     final PublicKey unrestrictedPublicKey = KeyFactory.getInstance(publicKey.getAlgorithm()).generatePublic(new X509EncodedKeySpec(publicKey.getEncoded()));
                     final OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT);
                     // Initialize cipher for data encryption

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
@@ -128,21 +128,19 @@ public class BiometricKeystore implements IBiometricKeystore {
         }
         try {
             mKeyStore.load(null);
-            if (mKeyStore.isCertificateEntry(KEY_NAME)) {
-                // RSA key-pair
-                final Key key = mKeyStore.getKey(KEY_NAME, null);
-                if (key instanceof PrivateKey) {
-                    return new BiometricKeyEncryptorRsa(key);
-                }
-            } else {
-                // AES key
-                final Key key = mKeyStore.getKey(KEY_NAME, null);
-                if (key instanceof SecretKey) {
-                    return new BiometricKeyEncryptorAes(key);
-                }
+            final Key key = mKeyStore.getKey(KEY_NAME, null);
+            if (key instanceof SecretKey) {
+                // AES symmetric key
+                return new BiometricKeyEncryptorAes((SecretKey)key);
+            } else if (key instanceof PrivateKey) {
+                // RSA private key
+                return new BiometricKeyEncryptorRsa((PrivateKey)key);
+            } else if (key != null) {
+                PA2Log.e("BiometricKeystore.getBiometricKeyEncryptor unknown key type: " + key.toString());
             }
             return null;
         } catch (NoSuchAlgorithmException | KeyStoreException | CertificateException | UnrecoverableKeyException | IOException e) {
+            PA2Log.e("BiometricKeystore.getBiometricKeyEncryptor failed: " + e.getMessage());
             return null;
         }
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
@@ -17,25 +17,23 @@
 package io.getlime.security.powerauth.biometry.impl;
 
 import android.os.Build;
-import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyProperties;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 
 import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
+import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.ProviderException;
+import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
-import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 import io.getlime.security.powerauth.biometry.IBiometricKeystore;
+import io.getlime.security.powerauth.system.PA2Log;
 
 /**
  * Class representing a Keystore used to store biometry related key.
@@ -53,6 +51,7 @@ public class BiometricKeystore implements IBiometricKeystore {
             mKeyStore = KeyStore.getInstance(PROVIDER_NAME);
             mKeyStore.load(null);
         } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
+            PA2Log.e("BiometricKeystore constructor failed: " + e.getMessage());
             mKeyStore = null;
         }
     }
@@ -72,13 +71,14 @@ public class BiometricKeystore implements IBiometricKeystore {
      * @return True in case a default key is present, false otherwise. Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
      */
     @Override
-    public boolean containsDefaultKey() {
+    public boolean containsBiometricKeyEncryptor() {
         if (!isKeystoreReady()) {
             return false;
         }
         try {
             return mKeyStore.containsAlias(KEY_NAME);
         } catch (KeyStoreException e) {
+            PA2Log.e("BiometricKeystore.containsBiometricKeyEncryptor failed: " + e.getMessage());
             return false;
         }
     }
@@ -88,42 +88,32 @@ public class BiometricKeystore implements IBiometricKeystore {
      *
      * The key that is created during this process is used to encrypt key stored in shared preferences,
      * in order to derive key used for biometric authentication.
-     *
+     * @param invalidateByBiometricEnrollment If true, then internal key stored in KeyStore will be invalidated on next biometric enrollment.
+     * @param useSymmetricKey If true, then symmetric key will be created.
      * @return New generated {@link SecretKey} key or {@code null} in case of failure.
      */
     @Override
-    public @Nullable SecretKey generateDefaultKey(boolean invalidateByBiometricEnrollment) {
-        try {
-            removeDefaultKey();
-            final KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, PROVIDER_NAME);
-            final KeyGenParameterSpec.Builder keySpecBuilder = new KeyGenParameterSpec.Builder(KEY_NAME, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setUserAuthenticationRequired(true)
-                    .setRandomizedEncryptionRequired(false)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                keySpecBuilder.setInvalidatedByBiometricEnrollment(invalidateByBiometricEnrollment);
-            }
-            keyGenerator.init(keySpecBuilder.build());
-            return keyGenerator.generateKey();
-        } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchProviderException | ProviderException e) {
-            return null;
+    public @Nullable
+    IBiometricKeyEncryptor createBiometricKeyEncryptor(boolean invalidateByBiometricEnrollment, boolean useSymmetricKey) {
+        removeBiometricKeyEncryptor();
+        if (useSymmetricKey) {
+            return BiometricKeyEncryptorAes.createAesEncryptor(PROVIDER_NAME, KEY_NAME, invalidateByBiometricEnrollment);
+        } else {
+            return BiometricKeyEncryptorRsa.createRsaEncryptor(PROVIDER_NAME, KEY_NAME, invalidateByBiometricEnrollment);
         }
     }
 
     /**
      * Removes an encryption key from Keystore.
-     * @return True in case key was removed, false otherwise.
      */
     @Override
-    public boolean removeDefaultKey() {
+    public void removeBiometricKeyEncryptor() {
         try {
-            if (containsDefaultKey()) {
+            if (containsBiometricKeyEncryptor()) {
                 mKeyStore.deleteEntry(KEY_NAME);
             }
-            return true;
         } catch (KeyStoreException e) {
-            return false;
+            PA2Log.e("BiometricKeystore.removeBiometricKeyEncryptor failed: " + e.getMessage());
         }
     }
 
@@ -131,13 +121,27 @@ public class BiometricKeystore implements IBiometricKeystore {
      * @return Default biometry related key, stored in KeyStore.
      */
     @Override
-    public @Nullable SecretKey getDefaultKey() {
+    @Nullable
+    public IBiometricKeyEncryptor getBiometricKeyEncryptor() {
         if (!isKeystoreReady()) {
             return null;
         }
         try {
             mKeyStore.load(null);
-            return (SecretKey) mKeyStore.getKey(KEY_NAME, null);
+            if (mKeyStore.isCertificateEntry(KEY_NAME)) {
+                // RSA key-pair
+                final Key key = mKeyStore.getKey(KEY_NAME, null);
+                if (key instanceof PrivateKey) {
+                    return new BiometricKeyEncryptorRsa(key);
+                }
+            } else {
+                // AES key
+                final Key key = mKeyStore.getKey(KEY_NAME, null);
+                if (key instanceof SecretKey) {
+                    return new BiometricKeyEncryptorAes(key);
+                }
+            }
+            return null;
         } catch (NoSuchAlgorithmException | KeyStoreException | CertificateException | UnrecoverableKeyException | IOException e) {
             return null;
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricResultDispatcher.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricResultDispatcher.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.biometry.impl;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import io.getlime.security.powerauth.biometry.BiometricKeyData;
 import io.getlime.security.powerauth.biometry.IBiometricAuthenticationCallback;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
@@ -110,13 +111,13 @@ public class BiometricResultDispatcher {
     /**
      * Report success to the {@link IBiometricAuthenticationCallback}.
      *
-     * @param encryptedKey Key encrypted with secret biometric key.
+     * @param biometricKeyData Biometric key data.
      */
-    public void dispatchSuccess(@NonNull final byte[] encryptedKey) {
+    public void dispatchSuccess(@NonNull final BiometricKeyData biometricKeyData) {
         dispatch(new Runnable() {
             @Override
             public void run() {
-                callback.onBiometricDialogSuccess(encryptedKey);
+                callback.onBiometricDialogSuccess(biometricKeyData);
             }
         });
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
@@ -20,10 +20,9 @@ import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import javax.crypto.SecretKey;
-
 import io.getlime.security.powerauth.biometry.BiometricAuthenticationRequest;
 import io.getlime.security.powerauth.biometry.BiometricDialogResources;
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 
 /**
  * The {@code PrivateRequestData} class contains various temporary data required for the biometric
@@ -35,8 +34,6 @@ public class PrivateRequestData {
     private final @NonNull BiometricResultDispatcher dispatcher;
     private final @NonNull BiometricDialogResources resources;
     private final long creationTime;
-
-    private @Nullable SecretKey secretKey;
 
     /**
      * Construct private request data object.
@@ -73,26 +70,6 @@ public class PrivateRequestData {
      */
     public @NonNull BiometricDialogResources getResources() {
         return resources;
-    }
-
-    /**
-     * Set secret key to the private request data object. The secret key has to be set before the
-     * authentication is performed on the device implementation.
-     * @param secretKey {@link SecretKey} object with the key protected by the biometry.
-     */
-    public void setSecretKey(@NonNull SecretKey secretKey) {
-        this.secretKey = secretKey;
-    }
-
-    /**
-     * @return {@link SecretKey} object with the key protected by the biometry. Method throws
-     *         {@code IllegalStateException} in case that key was not set before.
-     */
-    public @NonNull SecretKey getSecretKey() {
-        if (secretKey == null) {
-            throw new IllegalStateException("SecretKey is null.");
-        }
-        return secretKey;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
@@ -18,11 +18,9 @@ package io.getlime.security.powerauth.biometry.impl;
 
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import io.getlime.security.powerauth.biometry.BiometricAuthenticationRequest;
 import io.getlime.security.powerauth.biometry.BiometricDialogResources;
-import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 
 /**
  * The {@code PrivateRequestData} class contains various temporary data required for the biometric

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/dummy/DummyBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/dummy/DummyBiometricKeystore.java
@@ -18,8 +18,7 @@ package io.getlime.security.powerauth.biometry.impl.dummy;
 
 import android.support.annotation.Nullable;
 
-import javax.crypto.SecretKey;
-
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 import io.getlime.security.powerauth.biometry.IBiometricKeystore;
 
 /**
@@ -34,24 +33,23 @@ public class DummyBiometricKeystore implements IBiometricKeystore {
     }
 
     @Override
-    public boolean containsDefaultKey() {
+    public boolean containsBiometricKeyEncryptor() {
         return false;
     }
 
     @Nullable
     @Override
-    public SecretKey generateDefaultKey(boolean invalidateByBiometricEnrollment) {
+    public IBiometricKeyEncryptor createBiometricKeyEncryptor(boolean invalidateByBiometricEnrollment, boolean useSymmetricKey) {
         return null;
     }
 
     @Override
-    public boolean removeDefaultKey() {
-        return false;
+    public void removeBiometricKeyEncryptor() {
     }
 
     @Nullable
     @Override
-    public SecretKey getDefaultKey() {
+    public IBiometricKeyEncryptor getBiometricKeyEncryptor() {
         return null;
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/legacy/FingerprintAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/legacy/FingerprintAuthenticator.java
@@ -154,7 +154,7 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
         final BiometricAuthenticationRequest request = requestData.getRequest();
         final BiometricResultDispatcher dispatcher = requestData.getDispatcher();
 
-        // Now construct AES cipher with the biometric key, wrapped in the crypto object.
+        // Now construct appropriate cipher with the biometric key, wrapped in the crypto object.
         final FingerprintManager.CryptoObject cryptoObject = wrapCipherToCryptoObject(request.getBiometricKeyEncryptor().initializeCipher(request.isForceGenerateNewKey()));
         if (cryptoObject == null) {
             throw new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeBiometryNotSupported, "Cannot create CryptoObject for biometric authentication.");

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/legacy/FingerprintAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/legacy/FingerprintAuthenticator.java
@@ -28,12 +28,13 @@ import android.support.v4.app.FragmentManager;
 import android.util.Pair;
 
 import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
 
 import io.getlime.security.powerauth.biometry.BiometricAuthenticationRequest;
 import io.getlime.security.powerauth.biometry.BiometricDialogResources;
+import io.getlime.security.powerauth.biometry.BiometricKeyData;
 import io.getlime.security.powerauth.biometry.BiometricStatus;
 import io.getlime.security.powerauth.biometry.BiometryType;
+import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 import io.getlime.security.powerauth.biometry.IBiometricKeystore;
 import io.getlime.security.powerauth.biometry.impl.BiometricErrorDialogFragment;
 import io.getlime.security.powerauth.biometry.impl.BiometricHelper;
@@ -59,6 +60,9 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
     private final @NonNull FingerprintManager fingerprintManager;
     private final @NonNull IBiometricKeystore keystore;
     private byte[] alreadyProtectedKey;
+
+    private BiometricKeyData processedBiometricKeyData;
+    private boolean hasAlreadyProcessedBiometricKeyData;
 
     // Device construction
 
@@ -140,7 +144,7 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
         return keystore;
     }
 
-    @Nullable
+    @NonNull
     @Override
     public ICancelable authenticate(@NonNull final Context context,
                                     @NonNull final FragmentManager fragmentManager,
@@ -151,7 +155,7 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
         final BiometricResultDispatcher dispatcher = requestData.getDispatcher();
 
         // Now construct AES cipher with the biometric key, wrapped in the crypto object.
-        final FingerprintManager.CryptoObject cryptoObject = getCryptoObject(requestData.getSecretKey());
+        final FingerprintManager.CryptoObject cryptoObject = wrapCipherToCryptoObject(request.getBiometricKeyEncryptor().initializeCipher(request.isForceGenerateNewKey()));
         if (cryptoObject == null) {
             throw new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeBiometryNotSupported, "Cannot create CryptoObject for biometric authentication.");
         }
@@ -177,9 +181,9 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
             public void onAuthenticationSuccess(@NonNull FingerprintManager.AuthenticationResult result) {
                 final Cipher cipher = result.getCryptoObject() != null ? result.getCryptoObject().getCipher() : null;
                 if (cipher != null) {
-                    final byte[] protectedKey = protectKeyWithCipher(request.getKeyToProtect(), cipher);
-                    if (protectedKey != null) {
-                        dispatcher.dispatchSuccess(protectedKey);
+                    final BiometricKeyData biometricKeyData = encryptOrDecryptRawKeyData(request);
+                    if (biometricKeyData != null) {
+                        dispatcher.dispatchSuccess(biometricKeyData);
                         return;
                     }
                     PA2Log.e("Failed to encrypt biometric key.");
@@ -255,45 +259,36 @@ public class FingerprintAuthenticator implements IBiometricAuthenticator {
     // Private methods
 
     /**
-     * Construct an AES cipher with given secret key and return that cipher wrapped into {@link FingerprintManager.CryptoObject}.
+     * Wrap {@link Cipher} into {@link FingerprintManager.CryptoObject}.
      *
-     * @param secretKey A secret key that be used to AES cipher.
-     * @return {@link FingerprintManager.CryptoObject} created for AES cipher with given key or {@code null}
-     *         in case of failure.
+     * @param cipher A cipher object that must be wrapped.
+     * @return {@link FingerprintManager.CryptoObject} created for given cipher.
      */
-    private @Nullable FingerprintManager.CryptoObject getCryptoObject(@Nullable SecretKey secretKey) {
-        // Test whether the key is null
-        if (secretKey == null) {
-            return null;
-        }
-        // Create AES cipher with given key
-        final Cipher cipher = BiometricHelper.createAesCipher(secretKey);
-        if (cipher == null) {
-            return null;
-        }
+    private @Nullable FingerprintManager.CryptoObject wrapCipherToCryptoObject(@Nullable Cipher cipher) {
         // Wrap cipher into required crypto object
-        return new FingerprintManager.CryptoObject(cipher);
+        return cipher != null ? new FingerprintManager.CryptoObject(cipher) : null;
     }
 
     /**
-     * Protect key with Cipher, initialized with the biometric key.
+     * Encrypt or decrypt raw key data from biometric request.
      *
-     * @param keyToProtect Key which will be encrypted with biometric key.
-     * @param cipher Cipher initialized with the biometric key.
+     * @param request Biometric request data.
      * @return Encrypted bytes or {@code null} in case that encryption fails.
      */
-    private @Nullable byte[] protectKeyWithCipher(@NonNull byte[] keyToProtect, @NonNull Cipher cipher) {
+    private @Nullable BiometricKeyData encryptOrDecryptRawKeyData( @NonNull BiometricAuthenticationRequest request) {
         synchronized (this) {
-            if (alreadyProtectedKey == null) {
-                alreadyProtectedKey = BiometricHelper.protectKeyWithCipher(keyToProtect, cipher);
-                if (alreadyProtectedKey == null) {
-                    // Failed to encrypt provided key. Allocating array with zero bytes we indicate
-                    // that an attempt to encrypt key failed with the error.
-                    alreadyProtectedKey = new byte[0];
+            if (!hasAlreadyProcessedBiometricKeyData) {
+                hasAlreadyProcessedBiometricKeyData = true;
+                // Let's try to encrypt or decrypt the biometric key
+                final byte[] rawKeyData = request.getRawKeyData();
+                final IBiometricKeyEncryptor encryptor = request.getBiometricKeyEncryptor();
+                if (request.isForceGenerateNewKey()) {
+                    processedBiometricKeyData = encryptor.encryptBiometricKey(rawKeyData);
+                } else {
+                    processedBiometricKeyData = encryptor.decryptBiometricKey(rawKeyData);
                 }
             }
-            // If alreadyProtectedKey contains bytes, then return that bytes, otherwise null.
-            return alreadyProtectedKey.length > 0 ? alreadyProtectedKey : null;
+            return processedBiometricKeyData;
         }
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.exception;
 
+import android.support.annotation.NonNull;
+
 /**
  * Will be thrown, or will be returned to listener, in case that requested operation fails
  * on an error.
@@ -26,7 +28,7 @@ public class PowerAuthErrorException extends Exception {
      * Integer constant from {@link PowerAuthErrorCodes} class.
      */
     @PowerAuthErrorCodes
-    private int powerAuthErrorCode;
+    private final int powerAuthErrorCode;
 
     /**
      * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}
@@ -45,10 +47,54 @@ public class PowerAuthErrorException extends Exception {
     }
 
     /**
+     * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}
+     * @param message String with detailed error description.
+     * @param cause Original cause of failure.
+     */
+    public PowerAuthErrorException(@PowerAuthErrorCodes int powerAuthErrorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.powerAuthErrorCode = powerAuthErrorCode;
+    }
+
+    /**
      * @return Integer constant from {@link PowerAuthErrorCodes}, describing the reason of failure.
      */
     @PowerAuthErrorCodes
     public int getPowerAuthErrorCode() {
         return powerAuthErrorCode;
+    }
+
+    /**
+     * Wrap {@link Throwable} cause of failure into {@link PowerAuthErrorException} with provided
+     * error code and message. In case that original exception is already {@link PowerAuthErrorException},
+     * then return that object.
+     *
+     * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}.
+     * @param message String with detailed error description.
+     * @param exception Original cause of failure.
+     *
+     * @return Original exception if it's already instance of {@link PowerAuthErrorException} or
+     *         new instance of {@link PowerAuthErrorException}.
+     */
+    public static @NonNull PowerAuthErrorException wrapException(@PowerAuthErrorCodes int powerAuthErrorCode, String message, Throwable exception) {
+        if (exception instanceof PowerAuthErrorException) {
+            return (PowerAuthErrorException)exception;
+        }
+        return new PowerAuthErrorException(powerAuthErrorCode, message, exception);
+    }
+
+    /**
+     * Wrap {@link Throwable} cause of failure into {@link PowerAuthErrorException} with provided
+     * error code. In case that original exception is already {@link PowerAuthErrorException},
+     * then return that object.
+     *
+     * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}.
+     * @param exception Original cause of failure.
+     *
+     * @return Original exception if it's already instance of {@link PowerAuthErrorException} or
+     *         new instance of {@link PowerAuthErrorException}.
+     */
+    public static @NonNull PowerAuthErrorException wrapException(@PowerAuthErrorCodes int powerAuthErrorCode, Throwable exception) {
+        return wrapException(powerAuthErrorCode, null, exception);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
@@ -262,12 +262,12 @@ public class PowerAuthKeychainConfiguration {
          * <p>
          * The default value is {@code true}.
          *
-         * @param autheticate If set, then biometric authentication is required for both setup and usage
-         *                    of biometric key.
+         * @param authenticate If set, then biometric authentication is required for both setup and usage
+         *                     of biometric key.
          * @return {@link Builder}
          */
-        public @NonNull Builder authenticateOnBiometricKeySetup(boolean autheticate) {
-            this.authenticateOnBiometricKeySetup = autheticate;
+        public @NonNull Builder authenticateOnBiometricKeySetup(boolean authenticate) {
+            this.authenticateOnBiometricKeySetup = authenticate;
             return this;
         }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
@@ -31,6 +31,7 @@ public class PowerAuthKeychainConfiguration {
     public static final String KEYCHAIN_KEY_BIOMETRY_DEFAULT = "io.getlime.PowerAuthKeychain.BiometryKeychain.DefaultKey";
     public static final boolean DEFAULT_LINK_BIOMETRY_ITEMS_TO_CURRENT_SET = true;
     public static final boolean DEFAULT_CONFIRM_BIOMETRIC_AUTHENTICATION = false;
+    public static final boolean DEFAULT_AUTHENTICATE_ON_BIOMETRIC_KEY_SETUP = true;
     public static final @KeychainProtection int DEFAULT_REQUIRED_KEYCHAIN_PROTECTION = KeychainProtection.NONE;
 
     private final @NonNull String keychainIdStatus;
@@ -39,6 +40,7 @@ public class PowerAuthKeychainConfiguration {
     private final @NonNull String keychainKeyBiometryDefault;
     private final boolean linkBiometricItemsToCurrentSet;
     private final boolean confirmBiometricAuthentication;
+    private final boolean authenticateOnBiometricKeySetup;
     private final @KeychainProtection int minimalRequiredKeychainProtection;
 
     /**
@@ -100,6 +102,15 @@ public class PowerAuthKeychainConfiguration {
     }
 
     /**
+     * Get whether biometric authentication is required also for biometric key setup.
+     *
+     * @return {@code true} if biometric authentication is required for biometric key setup.
+     */
+    public boolean isAuthenticateOnBiometricKeySetup() {
+        return authenticateOnBiometricKeySetup;
+    }
+
+    /**
      * Get minimal required keychain protection level that must be supported on the current device.
      * If the level of protection on the device is insufficient, then you cannot use PowerAuth
      * mobile SDK on the device. If not configured, then {@link KeychainProtection#NONE} is used
@@ -124,6 +135,8 @@ public class PowerAuthKeychainConfiguration {
      * @param confirmBiometricAuthentication    If set, then the user's confirmation will be required after the successful
      *                                          biometric authentication. Note that this is just hint for the system
      *                                          and may be ignored.
+     * @param authenticateOnBiometricKeySetup   If set, then the biometric key setup always require biometric authentication.
+     *                                          If not set, then only usage of biometric key require biometric authentication.
      * @param minimalRequiredKeychainProtection {@link KeychainProtection} constant with minimal required keychain
      *                                          protection level that must be supported on the current device.
      */
@@ -134,6 +147,7 @@ public class PowerAuthKeychainConfiguration {
             @NonNull String keychainIdTokenStore,
             boolean linkBiometricItemsToCurrentSet,
             boolean confirmBiometricAuthentication,
+            boolean authenticateOnBiometricKeySetup,
             @KeychainProtection int minimalRequiredKeychainProtection) {
         this.keychainIdStatus = keychainIdStatus;
         this.keychainIdBiometry = keychainIdBiometry;
@@ -141,6 +155,7 @@ public class PowerAuthKeychainConfiguration {
         this.keychainIdTokenStore = keychainIdTokenStore;
         this.linkBiometricItemsToCurrentSet = linkBiometricItemsToCurrentSet;
         this.confirmBiometricAuthentication = confirmBiometricAuthentication;
+        this.authenticateOnBiometricKeySetup = authenticateOnBiometricKeySetup;
         this.minimalRequiredKeychainProtection = minimalRequiredKeychainProtection;
     }
 
@@ -155,6 +170,7 @@ public class PowerAuthKeychainConfiguration {
         private @NonNull String keychainBiometryDefaultKey = KEYCHAIN_KEY_BIOMETRY_DEFAULT;
         private boolean linkBiometricItemsToCurrentSet = DEFAULT_LINK_BIOMETRY_ITEMS_TO_CURRENT_SET;
         private boolean confirmBiometricAuthentication = DEFAULT_CONFIRM_BIOMETRIC_AUTHENTICATION;
+        private boolean authenticateOnBiometricKeySetup = DEFAULT_AUTHENTICATE_ON_BIOMETRIC_KEY_SETUP;
         private @KeychainProtection int minimalRequiredKeychainProtection = DEFAULT_REQUIRED_KEYCHAIN_PROTECTION;
 
         /**
@@ -234,6 +250,28 @@ public class PowerAuthKeychainConfiguration {
         }
 
         /**
+         * (Optional) Set, whether biometric key setup always require a biometric authentication.
+         * <p>
+         * Setting parameter to {@code true} leads to use symmetric AES cipher on the background,
+         * so both configuration and usage of biometric key require the biometric authentication.
+         * <p>
+         * If set to {@code false}, then RSA cipher is used and only the usage of biometric key
+         * require the biometric authentication. This is due to fact, that RSA cipher can encrypt
+         * data with using it's public key available immediate after the key-pair is created in
+         * Android KeyStore.
+         * <p>
+         * The default value is {@code true}.
+         *
+         * @param autheticate If set, then biometric authentication is required for both setup and usage
+         *                    of biometric key.
+         * @return {@link Builder}
+         */
+        public @NonNull Builder authenticateOnBiometricKeySetup(boolean autheticate) {
+            this.authenticateOnBiometricKeySetup = autheticate;
+            return this;
+        }
+
+        /**
          * Set minimal required keychain protection level that must be supported on the current device. Note that
          * if you enforce protection higher that {@link KeychainProtection#NONE}, then your application must target
          * at least Android 6.0.
@@ -260,6 +298,7 @@ public class PowerAuthKeychainConfiguration {
                     keychainTokenStoreId,
                     linkBiometricItemsToCurrentSet,
                     confirmBiometricAuthentication,
+                    authenticateOnBiometricKeySetup,
                     minimalRequiredKeychainProtection);
         }
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executor;
 import io.getlime.security.powerauth.biometry.BiometricAuthentication;
 import io.getlime.security.powerauth.biometry.BiometricAuthenticationRequest;
 import io.getlime.security.powerauth.biometry.BiometricKeyData;
+import io.getlime.security.powerauth.biometry.IAddBiometryFactorListener;
 import io.getlime.security.powerauth.biometry.IBiometricAuthenticationCallback;
 import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
 import io.getlime.security.powerauth.biometry.IBiometricKeystore;
@@ -83,7 +84,6 @@ import io.getlime.security.powerauth.networking.model.response.VaultUnlockRespon
 import io.getlime.security.powerauth.networking.response.CreateActivationResult;
 import io.getlime.security.powerauth.networking.response.IActivationRemoveListener;
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener;
-import io.getlime.security.powerauth.networking.response.IAddBiometryFactorListener;
 import io.getlime.security.powerauth.networking.response.IChangePasswordListener;
 import io.getlime.security.powerauth.networking.response.IConfirmRecoveryCodeListener;
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener;
@@ -1543,7 +1543,7 @@ public class PowerAuthSDK {
 
             @Override
             public void onFetchEncryptedVaultUnlockKeyFailed(Throwable t) {
-                listener.onAddBiometryFactorFailed(t);
+                listener.onAddBiometryFactorFailed(PowerAuthErrorException.wrapException(PowerAuthErrorCodes.PA2ErrorCodeNetworkError, t));
             }
         });
         if (httpRequest != null) {
@@ -1592,7 +1592,7 @@ public class PowerAuthSDK {
 
             @Override
             public void onFetchEncryptedVaultUnlockKeyFailed(Throwable t) {
-                listener.onAddBiometryFactorFailed(t);
+                listener.onAddBiometryFactorFailed(PowerAuthErrorException.wrapException(PowerAuthErrorCodes.PA2ErrorCodeNetworkError, t));
             }
         });
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DummyCancelable.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DummyCancelable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk.impl;
+
+import io.getlime.security.powerauth.networking.interfaces.ICancelable;
+
+/**
+ * The {@code DummyCancelable} object implements {@link ICancelable} interface with a dummy
+ * implementation that's already canceled. The object is useful in situations, when {@link ICancelable}
+ * must be returned from the function, but operation already finished with an error.
+ */
+public class DummyCancelable implements ICancelable {
+    @Override
+    public void cancel() {
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds support for biometric factor protected by asymmetric RSA key-pair, stored in Android keystore.