### PR TITLE
iOS: Fix #367: Prepare PowerAuthAuthentication for possession+biometry in advance (1.5.x)

### DIFF
--- a/proj-xcode/Classes/core/PA2ErrorConstants.h
+++ b/proj-xcode/Classes/core/PA2ErrorConstants.h
@@ -57,6 +57,12 @@ PA2_EXTERN_C NSInteger const PA2ErrorCodeBiometryNotAvailable;
 PA2_EXTERN_C NSInteger const PA2ErrorCodeBiometryCancel;
 
 /**
+ Error code for biometric authentication failure. This can happen when biometric authentication is requested
+ and is not configured, or when failed to acquire biometry key from the keychain.
+ */
+PA2_EXTERN_C NSInteger const PA2ErrorCodeBiometryFailed;
+
+/**
  Error code for canceled operation. This kind of error may occur in situations, when SDK
  needs to cancel an asynchronous operation, but the cancel is not initiated by the application
  itself. For example, if you reset the state of `PowerAuthSDK` during the pending

--- a/proj-xcode/Classes/core/PA2ErrorConstants.m
+++ b/proj-xcode/Classes/core/PA2ErrorConstants.m
@@ -23,7 +23,6 @@ NSString *const PA2ErrorDomain					= @"PA2ErrorDomain";
 NSString *const PA2ErrorInfoKey_AdditionalInfo	= @"PA2ErrorInfoKey_AdditionalInfo";
 NSString *const PA2ErrorInfoKey_ResponseData	= @"PA2ErrorInfoKey_ResponseData";
 
-/** Error code for error with network connectivity or download */
 NSInteger const PA2ErrorCodeNetworkError				= 1;
 NSInteger const PA2ErrorCodeSignatureError				= 2;
 NSInteger const PA2ErrorCodeInvalidActivationState		= 3;
@@ -39,3 +38,4 @@ NSInteger const PA2ErrorCodeInvalidToken				= 14;
 NSInteger const PA2ErrorCodeWatchConnectivity			= 15;
 NSInteger const PA2ErrorCodeProtocolUpgrade				= 16;
 NSInteger const PA2ErrorCodePendingProtocolUpgrade		= 17;
+NSInteger const PA2ErrorCodeBiometryFailed				= 18;

--- a/proj-xcode/Classes/core/PA2PrivateMacros.m
+++ b/proj-xcode/Classes/core/PA2PrivateMacros.m
@@ -25,8 +25,34 @@ id PA2CastToImpl(id instance, Class desiredClass)
 	return nil;
 }
 
+static NSString * _GetDefaultErrorDescription(NSInteger errorCode, NSString * message)
+{
+	if (message) {
+		return message;	// Use message if it's already available.
+	}
+#define _CODE_DESC(ec, text) if (errorCode == ec) return text;
+	_CODE_DESC(PA2ErrorCodeNetworkError, @"Network error")
+	_CODE_DESC(PA2ErrorCodeSignatureError, @"Signature error")
+	_CODE_DESC(PA2ErrorCodeInvalidActivationState, @"Invalid activation state")
+	_CODE_DESC(PA2ErrorCodeInvalidActivationData, @"Invalid activation data")
+	_CODE_DESC(PA2ErrorCodeMissingActivation, @"Missing activation")
+	_CODE_DESC(PA2ErrorCodeActivationPending, @"Pending activation")
+	_CODE_DESC(PA2ErrorCodeBiometryNotAvailable, @"Biometry is not supported or is unavailable")
+	_CODE_DESC(PA2ErrorCodeBiometryCancel, @"User did cancel biometry authentication dialog")
+	_CODE_DESC(PA2ErrorCodeBiometryFailed, @"Biometry authentication failed")
+	_CODE_DESC(PA2ErrorCodeOperationCancelled, @"Operation was cancelled by SDK")
+	_CODE_DESC(PA2ErrorCodeEncryption, @"General encryption failure")
+	_CODE_DESC(PA2ErrorCodeWrongParameter, @"Invalid parameter provided to method")
+	_CODE_DESC(PA2ErrorCodeInvalidToken, @"Invalid or unknown token")
+	_CODE_DESC(PA2ErrorCodeWatchConnectivity, @"Watch connectivity error")
+	_CODE_DESC(PA2ErrorCodeProtocolUpgrade, @"Protocol upgrade error")
+	_CODE_DESC(PA2ErrorCodePendingProtocolUpgrade, @"Pending protocol ugprade, try later")
+#undef _CODE_DESC
+	return [NSString stringWithFormat:@"Unknown error %@", @(errorCode)];
+}
+
 NSError * PA2MakeError(NSInteger errorCode, NSString * message)
 {
-	NSDictionary * info = message ? @{ NSLocalizedDescriptionKey: message} : nil;
+	NSDictionary * info = @{ NSLocalizedDescriptionKey:  _GetDefaultErrorDescription(errorCode, message)};
 	return [NSError errorWithDomain:PA2ErrorDomain code:errorCode userInfo:info];
 }

--- a/proj-xcode/Classes/sdk/PowerAuthAuthentication.h
+++ b/proj-xcode/Classes/sdk/PowerAuthAuthentication.h
@@ -62,6 +62,12 @@
  */
 + (nonnull PowerAuthAuthentication*) possessionWithBiometry;
 /**
+ Returns a new instance of authentication object preconfigured for a combination of
+ possession and biometry factors and with prompt, displayed in the system biometric
+ authentication dialog.
+ */
++ (nonnull PowerAuthAuthentication*) possessionWithBiometryWithPrompt:(nonnull NSString*)biometryPrompt;
+/**
  Returns a new instance of authentication object preconfigured for combination of possesion
  and knowledge factor.
  */

--- a/proj-xcode/Classes/sdk/PowerAuthAuthentication.m
+++ b/proj-xcode/Classes/sdk/PowerAuthAuthentication.m
@@ -91,6 +91,15 @@
 	return auth;
 }
 
++ (PowerAuthAuthentication*) possessionWithBiometryWithPrompt:(NSString *)biometryPrompt
+{
+	PowerAuthAuthentication * auth = [[PowerAuthAuthentication alloc] init];
+	auth.usePossession = YES;
+	auth.useBiometry = YES;
+	auth.biometryPrompt = biometryPrompt;
+	return auth;
+}
+
 + (PowerAuthAuthentication*) possessionWithPassword:(NSString *)password
 {
 	PowerAuthAuthentication * auth = [[PowerAuthAuthentication alloc] init];

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.h
@@ -383,11 +383,24 @@
  */
 - (BOOL) removeBiometryFactor;
 
+/** Prepare PowerAuthAuthentication object for future PowerAuth signature calculation with a biometry and possession factors involved.
+ 
+ The method is useful for situations where business processes require compute two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created PowerAuthAuthentication object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations.
+  
+ Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
+ 
+ @param prompt A prompt displayed in TouchID or FaceID authentication dialog.
+ @param callback A callback with result, always executed on the main thread.
+ */
+- (void) authenticateUsingBiometryWithPrompt:(nonnull NSString *)prompt
+									callback:(nonnull void(^)(PowerAuthAuthentication * _Nullable authentication, NSError * _Nullable error))callback;
+
 /** Unlock all keys stored in a biometry related keychain and keeps them cached for the scope of the block.
  
- There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger Touch ID twice. To avoid that, all Touch ID related keys are fetched at once and cached for a limited amount of time.
+ There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
  */
-- (void) unlockBiometryKeysWithPrompt:(nonnull NSString*)prompt withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, bool userCanceled))block;
+- (void) unlockBiometryKeysWithPrompt:(nonnull NSString*)prompt
+							withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block;
 
 /** Generate an derived encryption key with given index.
  


### PR DESCRIPTION
* Added missing biometry lock in unlockBiometryKeysWithPrompt method
* Added PowerAuthAuthentication static method to make possession+biometry with prompt
* Added new PA2ErrorCodeBiometryFailed error constant
* iOS: Core: Fix #376: Add text description to NSErrors

This is backport from develop to 1.5.x branch