### PR TITLE
Issues/356 ios biometry fallback

### DIFF
--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -821,7 +821,7 @@ let configuration = PowerAuthConfiguration()
 // ...
 
 // Prepare PowerAuthKeychainConfiguration
-// Set false to 'linkBiometricItemsToCurrentSet' property.
+// Set true to 'linkBiometricItemsToCurrentSet' property.
 let keychainConfiguration = PowerAuthKeychainConfiguration()
 keychainConfiguration.linkBiometricItemsToCurrentSet = true
 
@@ -831,8 +831,35 @@ PowerAuthSDK.initSharedInstance(configuration, keychainConfiguration: keychainCo
 let sdk = PowerAuthSDK(configuration: configuration, keychainConfiguration: keychainConfiguration, clientConfiguration: nil)
 ```
 
+<!-- begin box warning -->
 Be aware that the configuration above is effective only for the new keys. So, if your application is already using the biometry factor-related key with a different configuration, then the configuration change doesn't change the existing key. You have to [disable](#disable-biometry) and [enable](#enable-biometry) biometry to apply the change.
+<!-- end -->
 
+### Fallback biometry to device passcode
+
+By default, the fallback from biometric authentication to authenticate with device's passcode is not allowed. To change this behavior, you have to provide `PowerAuthKeychainConfiguration` object with `allowBiometricAuthenticationFallbackToDevicePasscode` parameter set to `true` and use that configuration for the `PowerAuthSDK` instance construction:
+
+```swift
+// Prepare your PA config
+let configuration = PowerAuthConfiguration()
+// ...
+
+// Prepare PowerAuthKeychainConfiguration
+// Set true to 'allowBiometricAuthenticationFallbackToDevicePasscode' property.
+let keychainConfiguration = PowerAuthKeychainConfiguration()
+keychainConfiguration.allowBiometricAuthenticationFallbackToDevicePasscode = true
+
+// Init shared PowerAuthSDK instance
+PowerAuthSDK.initSharedInstance(configuration, keychainConfiguration: keychainConfiguration, clientConfiguration: nil)
+// ...or create your own
+let sdk = PowerAuthSDK(configuration: configuration, keychainConfiguration: keychainConfiguration, clientConfiguration: nil)
+``` 
+
+Once the configuration above is used, then `linkBiometricItemsToCurrentSet` option has no effect on the biometry factor-related key lifetime. 
+
+<!-- begin box warning -->
+It's not recommended to allow fallback to device passcode if your application falls under EU banking regulations or your application needs to distinguish between the biometric and the knowledge-factor based signatures. This is due to the fact that if the biometry factor-related key is unlocked with the device's passcode, then it's no longer a biometric signature.
+<!-- end -->
 
 ## Activation Removal
 

--- a/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
@@ -1344,7 +1344,7 @@
 		BF4DBB931CDF3130008F3A47 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Lime - HighTech Solutions s.r.o.";
 				TargetAttributes = {
 					BF4DBCCC1CDF9CDE008F3A47 = {

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2/PowerAuthKeychain.h
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychain.h
@@ -111,6 +111,10 @@ typedef NS_ENUM(NSInteger, PowerAuthKeychainItemAccess) {
 	 Constraint to access an item with Touch ID for any enrolled fingers, or Face ID.
 	 */
 	PowerAuthKeychainItemAccess_AnyBiometricSet,
+	/**
+	 Constraint to access an item with any enrolled biometry or device's passcode.
+	 */
+	PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode,
 };
 
 /** Simple wrapper on top of an iOS Keychain.

--- a/proj-xcode/PowerAuth2/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychain.m
@@ -34,11 +34,13 @@
 
 #pragma mark - Initializer
 
-- (instancetype) initWithIdentifier:(NSString*)identifier {
+- (instancetype) initWithIdentifier:(NSString*)identifier
+{
 	return [self initWithIdentifier:identifier accessGroup:nil];
 }
 
-- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup {
+- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup
+{
 	self = [super init];
 	if (self) {
 		_identifier = identifier;
@@ -87,7 +89,8 @@
 
 #pragma mark - Updating existing records
 
-- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key {
+- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key
+{
 	if ([self containsDataForKey:key]) {
 		return [self implUpdateValue:data forKey:key];
 	} else {
@@ -95,7 +98,8 @@
 	}
 }
 
-- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion {
+- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion
+{
 	[self containsDataForKey:key completion:^(BOOL containsValue) {
 		if (containsValue) {
 			completion([self implUpdateValue:data forKey:key]);
@@ -107,19 +111,22 @@
 
 #pragma mark - Removing records
 
-- (BOOL)deleteDataForKey:(NSString *)key {
+- (BOOL)deleteDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
 	return SecItemDelete((__bridge CFDictionaryRef)(query)) == errSecSuccess;
 }
 
-- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion {
+- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		completion([self deleteDataForKey:key]);
 	});
 }
 
-+ (void) deleteAllData {
++ (void) deleteAllData
+{
     NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,
                                 (__bridge id)kSecClassInternetPassword,
                                 (__bridge id)kSecClassCertificate,
@@ -131,7 +138,8 @@
     }
 }
 
-- (void) deleteAllData {
+- (void) deleteAllData
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -140,12 +148,13 @@
 
 #pragma mark - Obtaining record information
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status {
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status
+{
 	return [self dataForKey:key status:status prompt:nil];
 }
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt {
-	
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt
+{
 	// Build query
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
@@ -169,7 +178,8 @@
 	}
 }
 
-- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status prompt:prompt];
@@ -177,7 +187,8 @@
 	});
 }
 
-- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status];
@@ -199,7 +210,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (BOOL) containsDataForKey:(NSString *)key {
+- (BOOL) containsDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -224,7 +236,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion {
+- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		BOOL containsValue = [self containsDataForKey:key];
 		completion(containsValue);
@@ -233,11 +246,13 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
 #pragma mark - Data in-memory caching
 
-- (NSDictionary*) allItems {
+- (NSDictionary*) allItems
+{
     return [self allItemsWithPrompt:nil withStatus:nil];
 }
 
-- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status {
+- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status
+{
     // Build query to return all results
     NSMutableDictionary *query = [_baseQuery mutableCopy];
     [query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
@@ -383,13 +398,18 @@ static PowerAuthBiometricAuthenticationInfo _getBiometryInfo()
 static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeychainItemAccess access)
 {
 	if (access != PowerAuthKeychainItemAccess_None) {
-		// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
-		// or use kNilOptions.
 		if (@available(iOS 9, *)) {
-			if (access == PowerAuthKeychainItemAccess_AnyBiometricSet) {
-				return __kSecAccessControlBiometryAny;
-			} else {
-				return __kSecAccessControlBiometryCurrentSet;
+			// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
+			// or use kNilOptions.
+			switch (access) {
+				case PowerAuthKeychainItemAccess_AnyBiometricSet:
+					return __kSecAccessControlBiometryAny;
+				case PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode:
+					return __kSecAccessControlBiometryAny | kSecAccessControlOr | kSecAccessControlDevicePasscode;
+				case PowerAuthKeychainItemAccess_CurrentBiometricSet:
+					return __kSecAccessControlBiometryCurrentSet;
+				default:
+					break;
 			}
 		}
 	}

--- a/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.h
@@ -101,6 +101,13 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL linkBiometricItemsToCurrentSet;
 
+/**
+ If set to YES, then the item protected with the biometry can be accessed also with a device passcode.
+ If set, then `linkBiometricItemsToCurrentSet` option has no effect. The default is NO, so fallback
+ to device's passcode is not enabled.
+ */
+@property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.m
@@ -43,6 +43,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		_keychainKey_Possession				= PowerAuthKeychainKey_Possession;
 		// Default config for biometry protected items
 		_linkBiometricItemsToCurrentSet = NO;
+		_allowBiometricAuthenticationFallbackToDevicePasscode = NO;
 	}
 	return self;
 }
@@ -59,6 +60,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		c->_keychainInstanceName_TokenStore = _keychainInstanceName_TokenStore;
 		c->_keychainKey_Possession = _keychainKey_Possession;
 		c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
+		c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
 	}
 	return c;
 }

--- a/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.m
+++ b/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.m
@@ -58,7 +58,9 @@
 
 - (PowerAuthKeychainItemAccess) biometricItemAccess
 {
-	if (self.linkBiometricItemsToCurrentSet) {
+	if (self.allowBiometricAuthenticationFallbackToDevicePasscode) {
+		return PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode;
+	} else if (self.linkBiometricItemsToCurrentSet) {
 		return PowerAuthKeychainItemAccess_CurrentBiometricSet;
 	} else {
 		return PowerAuthKeychainItemAccess_AnyBiometricSet;

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 		BF44F269263C3B0F00F3D498 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					BF44F271263C3B0F00F3D498 = {
 						CreatedOnToolsVersion = 12.4;

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.h
@@ -111,6 +111,10 @@ typedef NS_ENUM(NSInteger, PowerAuthKeychainItemAccess) {
 	 Constraint to access an item with Touch ID for any enrolled fingers, or Face ID.
 	 */
 	PowerAuthKeychainItemAccess_AnyBiometricSet,
+	/**
+	 Constraint to access an item with any enrolled biometry or device's passcode.
+	 */
+	PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode,
 };
 
 /** Simple wrapper on top of an iOS Keychain.

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
@@ -34,11 +34,13 @@
 
 #pragma mark - Initializer
 
-- (instancetype) initWithIdentifier:(NSString*)identifier {
+- (instancetype) initWithIdentifier:(NSString*)identifier
+{
 	return [self initWithIdentifier:identifier accessGroup:nil];
 }
 
-- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup {
+- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup
+{
 	self = [super init];
 	if (self) {
 		_identifier = identifier;
@@ -87,7 +89,8 @@
 
 #pragma mark - Updating existing records
 
-- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key {
+- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key
+{
 	if ([self containsDataForKey:key]) {
 		return [self implUpdateValue:data forKey:key];
 	} else {
@@ -95,7 +98,8 @@
 	}
 }
 
-- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion {
+- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion
+{
 	[self containsDataForKey:key completion:^(BOOL containsValue) {
 		if (containsValue) {
 			completion([self implUpdateValue:data forKey:key]);
@@ -107,19 +111,22 @@
 
 #pragma mark - Removing records
 
-- (BOOL)deleteDataForKey:(NSString *)key {
+- (BOOL)deleteDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
 	return SecItemDelete((__bridge CFDictionaryRef)(query)) == errSecSuccess;
 }
 
-- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion {
+- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		completion([self deleteDataForKey:key]);
 	});
 }
 
-+ (void) deleteAllData {
++ (void) deleteAllData
+{
     NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,
                                 (__bridge id)kSecClassInternetPassword,
                                 (__bridge id)kSecClassCertificate,
@@ -131,7 +138,8 @@
     }
 }
 
-- (void) deleteAllData {
+- (void) deleteAllData
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -140,12 +148,13 @@
 
 #pragma mark - Obtaining record information
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status {
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status
+{
 	return [self dataForKey:key status:status prompt:nil];
 }
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt {
-	
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt
+{
 	// Build query
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
@@ -169,7 +178,8 @@
 	}
 }
 
-- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status prompt:prompt];
@@ -177,7 +187,8 @@
 	});
 }
 
-- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status];
@@ -199,7 +210,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (BOOL) containsDataForKey:(NSString *)key {
+- (BOOL) containsDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -224,7 +236,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion {
+- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		BOOL containsValue = [self containsDataForKey:key];
 		completion(containsValue);
@@ -233,11 +246,13 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
 #pragma mark - Data in-memory caching
 
-- (NSDictionary*) allItems {
+- (NSDictionary*) allItems
+{
     return [self allItemsWithPrompt:nil withStatus:nil];
 }
 
-- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status {
+- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status
+{
     // Build query to return all results
     NSMutableDictionary *query = [_baseQuery mutableCopy];
     [query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
@@ -383,13 +398,18 @@ static PowerAuthBiometricAuthenticationInfo _getBiometryInfo()
 static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeychainItemAccess access)
 {
 	if (access != PowerAuthKeychainItemAccess_None) {
-		// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
-		// or use kNilOptions.
 		if (@available(iOS 9, *)) {
-			if (access == PowerAuthKeychainItemAccess_AnyBiometricSet) {
-				return __kSecAccessControlBiometryAny;
-			} else {
-				return __kSecAccessControlBiometryCurrentSet;
+			// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
+			// or use kNilOptions.
+			switch (access) {
+				case PowerAuthKeychainItemAccess_AnyBiometricSet:
+					return __kSecAccessControlBiometryAny;
+				case PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode:
+					return __kSecAccessControlBiometryAny | kSecAccessControlOr | kSecAccessControlDevicePasscode;
+				case PowerAuthKeychainItemAccess_CurrentBiometricSet:
+					return __kSecAccessControlBiometryCurrentSet;
+				default:
+					break;
 			}
 		}
 	}

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.h
@@ -101,6 +101,13 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL linkBiometricItemsToCurrentSet;
 
+/**
+ If set to YES, then the item protected with the biometry can be accessed also with a device passcode.
+ If set, then `linkBiometricItemsToCurrentSet` option has no effect. The default is NO, so fallback
+ to device's passcode is not enabled.
+ */
+@property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.m
@@ -43,6 +43,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		_keychainKey_Possession				= PowerAuthKeychainKey_Possession;
 		// Default config for biometry protected items
 		_linkBiometricItemsToCurrentSet = NO;
+		_allowBiometricAuthenticationFallbackToDevicePasscode = NO;
 	}
 	return self;
 }
@@ -59,6 +60,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		c->_keychainInstanceName_TokenStore = _keychainInstanceName_TokenStore;
 		c->_keychainKey_Possession = _keychainKey_Possession;
 		c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
+		c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
 	}
 	return c;
 }

--- a/proj-xcode/PowerAuth2ForWatch.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2ForWatch.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 		BF86E806263C1DDF004C8AE5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					BF86E80E263C1DDF004C8AE5 = {
 						CreatedOnToolsVersion = 12.4;

--- a/proj-xcode/PowerAuth2ForWatch.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForWatch.xcscheme
+++ b/proj-xcode/PowerAuth2ForWatch.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForWatch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.h
@@ -111,6 +111,10 @@ typedef NS_ENUM(NSInteger, PowerAuthKeychainItemAccess) {
 	 Constraint to access an item with Touch ID for any enrolled fingers, or Face ID.
 	 */
 	PowerAuthKeychainItemAccess_AnyBiometricSet,
+	/**
+	 Constraint to access an item with any enrolled biometry or device's passcode.
+	 */
+	PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode,
 };
 
 /** Simple wrapper on top of an iOS Keychain.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
@@ -34,11 +34,13 @@
 
 #pragma mark - Initializer
 
-- (instancetype) initWithIdentifier:(NSString*)identifier {
+- (instancetype) initWithIdentifier:(NSString*)identifier
+{
 	return [self initWithIdentifier:identifier accessGroup:nil];
 }
 
-- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup {
+- (instancetype) initWithIdentifier:(NSString*)identifier accessGroup:(NSString*)accessGroup
+{
 	self = [super init];
 	if (self) {
 		_identifier = identifier;
@@ -87,7 +89,8 @@
 
 #pragma mark - Updating existing records
 
-- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key {
+- (PowerAuthKeychainStoreItemResult)updateValue:(NSData *)data forKey:(NSString *)key
+{
 	if ([self containsDataForKey:key]) {
 		return [self implUpdateValue:data forKey:key];
 	} else {
@@ -95,7 +98,8 @@
 	}
 }
 
-- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion {
+- (void)updateValue:(NSData *)data forKey:(NSString *)key completion:(void (^)(PowerAuthKeychainStoreItemResult))completion
+{
 	[self containsDataForKey:key completion:^(BOOL containsValue) {
 		if (containsValue) {
 			completion([self implUpdateValue:data forKey:key]);
@@ -107,19 +111,22 @@
 
 #pragma mark - Removing records
 
-- (BOOL)deleteDataForKey:(NSString *)key {
+- (BOOL)deleteDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
 	return SecItemDelete((__bridge CFDictionaryRef)(query)) == errSecSuccess;
 }
 
-- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion {
+- (void) deleteDataForKey:(NSString*)key completion:(void(^)(BOOL deleted))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		completion([self deleteDataForKey:key]);
 	});
 }
 
-+ (void) deleteAllData {
++ (void) deleteAllData
+{
     NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,
                                 (__bridge id)kSecClassInternetPassword,
                                 (__bridge id)kSecClassCertificate,
@@ -131,7 +138,8 @@
     }
 }
 
-- (void) deleteAllData {
+- (void) deleteAllData
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -140,12 +148,13 @@
 
 #pragma mark - Obtaining record information
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status {
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status
+{
 	return [self dataForKey:key status:status prompt:nil];
 }
 
-- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt {
-	
+- (NSData*) dataForKey:(NSString *)key status:(OSStatus *)status prompt:(NSString*)prompt
+{
 	// Build query
 	NSMutableDictionary *query = [_baseQuery mutableCopy];
 	[query setValue:key forKey:(__bridge id)kSecAttrAccount];
@@ -169,7 +178,8 @@
 	}
 }
 
-- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key prompt:(NSString*)prompt completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status prompt:prompt];
@@ -177,7 +187,8 @@
 	});
 }
 
-- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion {
+- (void) dataForKey:(NSString*)key completion:(void(^)(NSData *data, OSStatus status))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		OSStatus status;
 		NSData *value = [self dataForKey:key status:&status];
@@ -199,7 +210,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (BOOL) containsDataForKey:(NSString *)key {
+- (BOOL) containsDataForKey:(NSString *)key
+{
 	NSMutableDictionary *query = [NSMutableDictionary dictionary];
 	[query setValue:_identifier								forKey:(__bridge id)kSecAttrService];
 	[query setValue:(__bridge id)kSecClassGenericPassword	forKey:(__bridge id)kSecClass];
@@ -224,7 +236,8 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 	}
 }
 
-- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion {
+- (void) containsDataForKey:(NSString*)key completion:(void(^)(BOOL containsValue))completion
+{
 	dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		BOOL containsValue = [self containsDataForKey:key];
 		completion(containsValue);
@@ -233,11 +246,13 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
 #pragma mark - Data in-memory caching
 
-- (NSDictionary*) allItems {
+- (NSDictionary*) allItems
+{
     return [self allItemsWithPrompt:nil withStatus:nil];
 }
 
-- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status {
+- (NSDictionary*) allItemsWithPrompt:(NSString*)prompt withStatus: (OSStatus *)status
+{
     // Build query to return all results
     NSMutableDictionary *query = [_baseQuery mutableCopy];
     [query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
@@ -383,13 +398,18 @@ static PowerAuthBiometricAuthenticationInfo _getBiometryInfo()
 static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeychainItemAccess access)
 {
 	if (access != PowerAuthKeychainItemAccess_None) {
-		// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
-		// or use kNilOptions.
 		if (@available(iOS 9, *)) {
-			if (access == PowerAuthKeychainItemAccess_AnyBiometricSet) {
-				return __kSecAccessControlBiometryAny;
-			} else {
-				return __kSecAccessControlBiometryCurrentSet;
+			// If the system version is iOS 9.0+, use biometry if requested (kSecAccessControlBiometryAny),
+			// or use kNilOptions.
+			switch (access) {
+				case PowerAuthKeychainItemAccess_AnyBiometricSet:
+					return __kSecAccessControlBiometryAny;
+				case PowerAuthKeychainItemAccess_AnyBiometricSetOrDevicePasscode:
+					return __kSecAccessControlBiometryAny | kSecAccessControlOr | kSecAccessControlDevicePasscode;
+				case PowerAuthKeychainItemAccess_CurrentBiometricSet:
+					return __kSecAccessControlBiometryCurrentSet;
+				default:
+					break;
 			}
 		}
 	}

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.h
@@ -101,6 +101,13 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL linkBiometricItemsToCurrentSet;
 
+/**
+ If set to YES, then the item protected with the biometry can be accessed also with a device passcode.
+ If set, then `linkBiometricItemsToCurrentSet` option has no effect. The default is NO, so fallback
+ to device's passcode is not enabled.
+ */
+@property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.m
@@ -43,6 +43,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		_keychainKey_Possession				= PowerAuthKeychainKey_Possession;
 		// Default config for biometry protected items
 		_linkBiometricItemsToCurrentSet = NO;
+		_allowBiometricAuthenticationFallbackToDevicePasscode = NO;
 	}
 	return self;
 }
@@ -59,6 +60,7 @@ NSString *const PowerAuthKeychainKey_Possession		= PA2Def_PowerAuthKeychainKey_P
 		c->_keychainInstanceName_TokenStore = _keychainInstanceName_TokenStore;
 		c->_keychainKey_Possession = _keychainKey_Possession;
 		c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
+		c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
 	}
 	return c;
 }

--- a/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
@@ -1035,7 +1035,7 @@
 		BF3ACC7D2073DBA500B8107E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Lime - HighTech Solutions";
 				TargetAttributes = {
 					BF3ACC842073DBA500B8107E = {

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_iOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_iOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_tvOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR adds support for fallback from biometric authentication to device passcode.
There's also one more commit to remove warnings after upgrade to Xcode 12.5

Note that `PowerAuthKeychain.m/h` and `PowerAuthKeychainConfiguration.m/h` is available also in watchOS or app extensions projects. It's just the same source code as is for main `PowerAuth2` library. 