### PR TITLE
iOS: Fix #409: Add support for WS-Security header in tests

### DIFF
--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/PowerAuthTestServerConfig.h
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/PowerAuthTestServerConfig.h
@@ -60,6 +60,14 @@ extern PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVe
  */
 @property (nonatomic, strong, readonly) NSString * soapApiUrl;
 /**
+ If set, then WS-Security header will be added to SOAP requests.
+ */
+@property (nonatomic, strong, readonly) NSString * soapAuthUsername;
+/**
+ If set, then WS-Security header will be added to SOAP requests.
+ */
+@property (nonatomic, strong, readonly) NSString * soapAuthPassword;
+/**
  String with version of SOAP API. "V2" & "V3" is expected in JSON config.
  "V2" is the default value.
  */

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/PowerAuthTestServerConfig.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/PowerAuthTestServerConfig.m
@@ -17,28 +17,15 @@
 #import "PowerAuthTestServerConfig.h"
 #import <UIKit/UIDevice.h>
 
-/**
- The `POWERAUTH_BASE_URL` macro defines a base URL where are the running server instances
- located. The default config expects that the SOAP & REST servers are running at "http://paserver"
- domain. If you're using a locally installed docker, then more common for you
- will be set the base URL to "http://localhost". 
- 
- NOTE: You should create a local configuration file instead of changing this source file.
-        Check TestConfig/Readme.md for details.
- */
-#ifndef POWERAUTH_BASE_URL
-#define POWERAUTH_BASE_URL @"http://localhost"
-#endif
-
 @implementation PowerAuthTestServerConfig
 
 + (instancetype) defaultConfig
 {
 	NSDictionary * dict =
 	@{
-	  @"restApiUrl"           : POWERAUTH_BASE_URL @":8080/powerauth-webauth",
-	  @"soapApiUrl"           : POWERAUTH_BASE_URL @":8080/powerauth-java-server/soap",
-	  @"soapApiVersion"       : @"0.24",
+	  @"restApiUrl"           : @"http://localhost:8080/powerauth-webauth",
+	  @"soapApiUrl"           : @"http://localhost:8080/powerauth-java-server/soap",
+	  @"soapApiVersion"       : @"1.1",
 	  @"powerAuthAppName"     : @"AutomaticTest-IOS",
 	  @"powerAuthAppVersion"  : @"default"
 	  
@@ -127,6 +114,8 @@ PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVer)
 	if (instance) {
 		instance->_restApiUrl = dict[@"restApiUrl"];
 		instance->_soapApiUrl = dict[@"soapApiUrl"];
+		instance->_soapAuthUsername = dict[@"soapAuthUsername"];
+		instance->_soapAuthPassword = dict[@"soapAuthPassword"];
 		instance->_soapApiVersion = [self soapApiVersionFromString:dict[@"soapApiVersion"]];
 		instance->_powerAuthAppName = dict[@"powerAuthAppName"];
 		instance->_powerAuthAppVersion = dict[@"powerAuthAppVersion"];

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/BlockActivation.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/BlockActivation.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:BlockActivationRequest>
          <pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CommitActivation.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CommitActivation.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:CommitActivationRequest>
          <pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateApplication.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateApplication.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:CreateApplicationRequest>
 			<pow:applicationName>$1</pow:applicationName>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateApplicationVersion.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateApplicationVersion.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:CreateApplicationVersionRequest>
 			<pow:applicationId>$1</pow:applicationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateNonPersonalizedOfflineSignaturePayload.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateNonPersonalizedOfflineSignaturePayload.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:CreateNonPersonalizedOfflineSignaturePayloadRequest>
 			<pow:applicationId>$1</pow:applicationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreatePersonalizedOfflineSignaturePayload.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreatePersonalizedOfflineSignaturePayload.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:CreatePersonalizedOfflineSignaturePayloadRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateToken.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/CreateToken.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:CreateTokenRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetActivationStatus.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetActivationStatus.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:GetActivationStatusRequest>
          <pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetActivationStatus_Challenge.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetActivationStatus_Challenge.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:GetActivationStatusRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetApplicationDetail.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetApplicationDetail.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:GetApplicationDetailRequest>
 			<pow:applicationId>$1</pow:applicationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetApplicationList.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetApplicationList.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:GetApplicationListRequest/>
 	</soapenv:Body>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetSystemStatus.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/GetSystemStatus.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:GetSystemStatusRequest/>
    </soapenv:Body>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/InitActivation.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/InitActivation.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:InitActivationRequest>
          <pow:userId>$1</pow:userId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/InitActivation_OTP.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/InitActivation_OTP.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:InitActivationRequest>
          <pow:userId>$1</pow:userId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/RemoveActivation.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/RemoveActivation.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:RemoveActivationRequest>
          <pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/RemoveToken.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/RemoveToken.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:RemoveTokenRequest>
 			<pow:tokenId>$1</pow:tokenId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/SupportApplicationVersion.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/SupportApplicationVersion.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+    $HDR
 	<soapenv:Body>
 		<pow:SupportApplicationVersionRequest>
 			<pow:applicationVersionId>$1</pow:applicationVersionId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/UnblockActivation.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/UnblockActivation.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-   <soapenv:Header/>
+   $HDR
    <soapenv:Body>
       <pow:UnblockActivationRequest>
          <pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/UnsupportApplicationVersion.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/UnsupportApplicationVersion.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:UnsupportApplicationVersionRequest>
 			<pow:applicationVersionId>$1</pow:applicationVersionId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/ValidateToken.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/ValidateToken.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:ValidateTokenRequest>
 			<pow:tokenId>$1</pow:tokenId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifyECDSASignature.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifyECDSASignature.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:VerifyECDSASignatureRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifyOfflineSignature.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifyOfflineSignature.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:VerifyOfflineSignatureRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifySignature.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifySignature.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:VerifySignatureRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifySignature_ForceVer.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/VerifySignature_ForceVer.xml
@@ -1,5 +1,5 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pow="$XMLNS">
-	<soapenv:Header/>
+	$HDR
 	<soapenv:Body>
 		<pow:VerifySignatureRequest>
 			<pow:activationId>$1</pow:activationId>

--- a/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/WS-Security.xml
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthServerSOAP/SoapRequests.bundle/WS-Security.xml
@@ -1,0 +1,8 @@
+<soapenv:Header>
+    <wsse:Security soapenv:mustUnderstand="1" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+        <wsse:UsernameToken>
+            <wsse:Username>$1</wsse:Username>
+            <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">$2</wsse:Password>
+        </wsse:UsernameToken>
+    </wsse:Security>
+</soapenv:Header>

--- a/proj-xcode/PowerAuth2Tests/TestConfig/Readme.md
+++ b/proj-xcode/PowerAuth2Tests/TestConfig/Readme.md
@@ -9,7 +9,7 @@ To do this, please follow these simple steps:
    {
 		"restApiUrl"           : "http://localhost:8080/powerauth-webflow",
 		"soapApiUrl"           : "http://localhost:8080/powerauth-java-server/soap",
-		"soapApiVersion"       : "0.24",
+		"soapApiVersion"       : "1.1",
 		"powerAuthAppName"     : "AutomaticTest-IOS",
 		"powerAuthAppVersion"  : "default"
    }
@@ -26,3 +26,5 @@ To do this, please follow these simple steps:
 6. Optional: You can devifine following additional keys in the dictionary:
    - `userIdentifier` - an user's identifier. It's recommended to set your own value when another developer is running tests against the same server.
    - `userActivationName` - a name will be used for newly created activations
+   - `soapAuthUsername` - an username in case that SOAP service needs authentication
+   - `soapAuthPassword` - a password in case that SOAP service needs authentication


### PR DESCRIPTION
Add support for WS-Security authentication header to SOAP client, in case that PowerAuth server requires an additional authentication.