### PR TITLE
Android: Fix #353: Catch ProviderException

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -108,7 +108,7 @@ public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
                 // Keep encrypt mode flag to be validated later in encrypt / decrypt methods.
                 this.encryptMode = encryptMode;
             }
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+        } catch (ProviderException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException e) {
             PowerAuthLog.e("BiometricKeyEncryptorAes.initializeCipher failed: " + e.getMessage());
             this.cipher = null;
         } finally {
@@ -161,7 +161,7 @@ public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
 
             // Derive the key
             return cipher.doFinal(keyToDerive);
-        } catch (BadPaddingException | IllegalBlockSizeException e) {
+        } catch (ProviderException | BadPaddingException | IllegalBlockSizeException e) {
             PowerAuthLog.e("BiometricKeyEncryptorAes.aesKdf failed: " + e.getMessage());
             return null;
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -31,6 +31,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.MGF1ParameterSpec;
@@ -140,7 +141,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
                 }
                 this.encryptMode = encryptMode;
             }
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+        } catch (ProviderException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException e) {
             PowerAuthLog.e("BiometricKeyEncryptorRsa.initializeCipher failed: " + e.getMessage());
             this.cipher = null;
         } finally {
@@ -171,7 +172,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
             // already the key, that will protect biometric factor for PowerAuth protocol.
             return new BiometricKeyData(encryptedBiometricKey, key, true);
 
-        } catch (BadPaddingException | IllegalBlockSizeException e) {
+        } catch (ProviderException | BadPaddingException | IllegalBlockSizeException e) {
             PowerAuthLog.e("BiometricKeyEncryptorRsa.encryptBiometricKey failed: " + e.getMessage());
             return null;
         }
@@ -199,7 +200,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
             // factor. Just for convenience, we'll return the same data as we received on input.
             return new BiometricKeyData(encryptedKey, decryptedKey, false);
 
-        } catch (BadPaddingException | IllegalBlockSizeException e) {
+        } catch (ProviderException | BadPaddingException | IllegalBlockSizeException e) {
             PowerAuthLog.e("BiometricKeyEncryptorRsa.decryptBiometricKey failed: " + e.getMessage());
             return null;
         }
@@ -230,7 +231,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
             final KeyPair keyPair = keyPairGenerator.generateKeyPair();
             final PublicKey publicKey = keyPair.getPublic();
             return new BiometricKeyEncryptorRsa(publicKey);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (ProviderException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             PowerAuthLog.e("BiometricKeyEncryptorRsa.createRsaEncryptor failed: " + e.getMessage());
             return null;
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/SymmetricKeyProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/SymmetricKeyProvider.java
@@ -30,6 +30,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.ProviderException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
@@ -377,7 +378,7 @@ public class SymmetricKeyProvider {
                     .build());
             return keyGenerator.generateKey();
 
-        } catch (StrongBoxUnavailableException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (ProviderException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             PowerAuthLog.d("SymmetricKeyProvider: " + keyAlias + ": Failed to generate new StrongBox backed key. Exception: " + e.getMessage());
             return null;
         }
@@ -400,7 +401,7 @@ public class SymmetricKeyProvider {
             keyGenerator.init(builder.build());
             return keyGenerator.generateKey();
 
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (ProviderException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             PowerAuthLog.e("SymmetricKeyProvider: " + keyAlias + ": Failed to generate new key. Exception: " + e.getMessage());
             return null;
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/AesGcmImpl.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/AesGcmImpl.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.ProviderException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -77,7 +78,8 @@ public class AesGcmImpl {
             System.arraycopy(cipher.getIV(), 0, ciphertext, 0, IV_SIZE_IN_BYTES);
             return ciphertext;
 
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException | IllegalBlockSizeException | ShortBufferException e) {
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException |
+                IllegalBlockSizeException | ShortBufferException | ProviderException e) {
             PowerAuthLog.e("AesGcmImpl: " + identifier + ": Failed to encrypt keychain value. Exception: " + e.getMessage());
             return null;
         }
@@ -105,7 +107,8 @@ public class AesGcmImpl {
             cipher.updateAAD(aad);
             return cipher.doFinal(ciphertext, IV_SIZE_IN_BYTES, ciphertext.length - IV_SIZE_IN_BYTES);
 
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException | BadPaddingException | IllegalBlockSizeException e) {
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException |
+                InvalidKeyException | BadPaddingException | IllegalBlockSizeException | ProviderException e) {
             PowerAuthLog.e("AesGcmImpl: " + identifier + ": Failed to decrypt keychain value. Exception: " + e.getMessage());
             return null;
         }


### PR DESCRIPTION
This fix catch `ProviderException` at various code paths, related to Android KeyStore based encryption & decryption.