### PR TITLE
Apple: Fix #419: Reset pending activation after failed ECIES.

### DIFF
--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -684,6 +684,8 @@ static PowerAuthSDK * s_inst;
 																 error:&localError];
 		if (!localError) {
 			decryptor = privateEncryptor;
+		} else {
+			[_session resetSession];
 		}
 	} else {
 		localError = PA2MakeError(PowerAuthErrorCode_InvalidActivationData, nil);


### PR DESCRIPTION
This is a fix for #419 back-ported to 1.6.x release branch.