### PR TITLE
Issues/188 tokens consistency

### DIFF
--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -23,6 +23,8 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
 - Interface `IFetchKeysStrategy` is now deprecated and will be removed in the next major SDK release.
   - There's `IPossessionFactorEncryptionKeyProvider` that SDK is using internally as a replacement. If your application depends on `IFetchKeysStrategy`, then please contact us to find a proper solution for you.
 
+- Method `PowerAuthSDK.removeActivationLocal(Context, boolean)` has no longer the context parameter optional, so the Context has to be always provided.
+
 ### Other changes
 
 - `BiometricAuthentication.isBiometricAuthenticationAvailable()` now better reflect the biometric authentication availability. The function is now internally implemented as `BiometricAuthentication.canAuthenticate() == BiometricStatus.OK`.
@@ -56,4 +58,4 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
 
 ### API changes
 
-- TBA
+- `PowerAuthWatchSDK.activationId` property is now deprecated. Please use `activationIdentifier` as a replacement.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1295,24 +1295,23 @@ public class PowerAuthSDK {
      * <b>NOTE:</b> This method is useful for situations, where the application has multiple SDK instances activated at the same time and
      * you need to manage a lifetime of shared biometry key.
      *
-     * @param context                   Context, may be null if removeSharedBiometryKey is false.
+     * @param context                   Android context.
      * @param removeSharedBiometryKey   If set to true, then also shared biometry key will be removed.
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      */
-    public void removeActivationLocal(@Nullable Context context, boolean removeSharedBiometryKey) {
+    public void removeActivationLocal(@NonNull Context context, boolean removeSharedBiometryKey) {
 
         checkForValidSetup();
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            if (removeSharedBiometryKey && mSession.hasBiometryFactor() && context != null) {
+            if (removeSharedBiometryKey && mSession.hasBiometryFactor()) {
                 mBiometryKeychain.remove(mKeychainConfiguration.getKeychainBiometryDefaultKey());
             }
             BiometricAuthentication.getBiometricKeystore().removeBiometricKeyEncryptor();
         }
         // Remove all tokens from token store
-        if (context != null) {
-            this.getTokenStore().removeAllLocalTokens(context);
-        }
+        getTokenStore().removeAllLocalTokens(context);
+
         // Reset C++ session
         mSession.resetSession();
         // Serialize will notify state listener

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthToken.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthToken.java
@@ -100,7 +100,7 @@ public class PowerAuthToken {
      * @return true if token can generate a new header
      */
     public boolean canGenerateHeader() {
-        return tokenStore.canRequestForAccessToken();
+        return tokenStore.canGenerateHeaderForToken(tokenData);
     }
 
     /**
@@ -112,7 +112,7 @@ public class PowerAuthToken {
     public @NonNull PowerAuthAuthorizationHttpHeader generateHeader() {
         @PowerAuthErrorCodes int errorCode;
         if (this.isValid()) {
-            if (tokenStore.canRequestForAccessToken()) {
+            if (tokenStore.canGenerateHeaderForToken(tokenData)) {
                 String headerValue = TokenCalculator.calculateTokenValue(tokenData);
                 if (headerValue != null) {
                     return PowerAuthAuthorizationHttpHeader.createTokenHeader(headerValue);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthTokenStore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthTokenStore.java
@@ -163,7 +163,9 @@ public class PowerAuthTokenStore {
             });
             return null;
         }
-
+        // Prepare activationID in advance, to do not store null when activation is suddenly
+        // removed during the operation.
+        final String activationIdentifier = sdk.getActivationIdentifier();
         // Execute HTTP request
         return httpClient.post(
                 null,
@@ -175,7 +177,7 @@ public class PowerAuthTokenStore {
                     public void onNetworkResponse(@NonNull TokenResponsePayload response) {
                         // Success, try to construct a new PowerAuthPrivateTokenData object.
                         final byte[] tokenSecretBytes = Base64.decode(response.getTokenSecret(), Base64.NO_WRAP);
-                        final PowerAuthPrivateTokenData newTokenData = new PowerAuthPrivateTokenData(tokenName, response.getTokenId(), tokenSecretBytes, sdk.getActivationIdentifier());
+                        final PowerAuthPrivateTokenData newTokenData = new PowerAuthPrivateTokenData(tokenName, response.getTokenId(), tokenSecretBytes, activationIdentifier);
                         if (newTokenData.hasValidData()) {
                             // Store token data & report to listener
                             storeTokenData(context, newTokenData);

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -225,11 +225,6 @@
 								error:(NSError * _Nullable * _Nullable)error;
 
 /**
- Read only property contains activation identifier or nil if object has no valid activation.
- */
-@property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
-
-/**
  Read only property contains fingerprint calculated from device's public key or nil if object has no valid activation.
  */
 @property (nonatomic, strong, nullable, readonly) NSString *activationFingerprint;

--- a/proj-xcode/PowerAuth2/PowerAuthSessionStatusProvider.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSessionStatusProvider.h
@@ -65,4 +65,9 @@
  */
 - (BOOL) hasPendingProtocolUpgrade;
 
+/**
+ Read only property contains activation identifier or nil if object has no valid activation.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
+
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthToken.m
+++ b/proj-xcode/PowerAuth2/PowerAuthToken.m
@@ -36,6 +36,7 @@
 @implementation PowerAuthToken
 {
 	PA2PrivateTokenData * _tokenData;
+	__weak id<PowerAuthPrivateTokenStore> _tokenStore;
 }
 
 #pragma mark - Public getters
@@ -62,7 +63,7 @@
 
 - (BOOL) canGenerateHeader
 {
-	return _tokenData != nil && _tokenStore.canRequestForAccessToken;
+	return _tokenData != nil && [_tokenStore canGenerateHeaderForToken:self];
 }
 
 #pragma mark - Public methods
@@ -142,7 +143,7 @@
 	return nil;
 }
 
-- (id) initWithStore:(id<PowerAuthTokenStore>)store
+- (id) initWithStore:(id<PowerAuthPrivateTokenStore>)store
 				data:(PA2PrivateTokenData*)data
 {
 	self = [super init];
@@ -151,6 +152,11 @@
 		_tokenData = data;
 	}
 	return self;
+}
+
+- (id<PowerAuthTokenStore>) tokenStore
+{
+	return _tokenStore;
 }
 
 #pragma mark - Debug

--- a/proj-xcode/PowerAuth2/private/PA2PrivateTokenData.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateTokenData.h
@@ -39,6 +39,11 @@
  Token's secret, received from the server.
  */
 @property (nonatomic, strong, nonnull) NSData * secret;
+/**
+ Identifier of activation associated with the token. If nil, then the serialized
+ data is still in old format and needs to be upgraded.
+ */
+@property (nonatomic, strong, nullable) NSString * activationIdentifier;
 
 #pragma mark - Compare
 

--- a/proj-xcode/PowerAuth2/private/PA2PrivateTokenData.m
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateTokenData.m
@@ -47,6 +47,7 @@
 	PA2PrivateTokenData * result = [[PA2PrivateTokenData alloc] init];
 	result.name		 			= PA2ObjectAs(dict[@"name"], NSString);
 	result.identifier			= PA2ObjectAs(dict[@"id"], NSString);
+	result.activationIdentifier = PA2ObjectAs(dict[@"aid"], NSString);
 	NSString * loadedB64Secret 	= PA2ObjectAs(dict[@"sec"], NSString);
 	NSData * loadedSecret 		= loadedB64Secret ? [[NSData alloc] initWithBase64EncodedString:loadedB64Secret options:0] : nil;
 	if (loadedSecret) {
@@ -63,7 +64,11 @@
 		return nil;
 	}
 	NSString * b64secret = [_secret base64EncodedStringWithOptions:0];
-	return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	if (_activationIdentifier != nil) {
+		return @{ @"name" : _name, @"id" : _identifier, @"aid": _activationIdentifier, @"sec": b64secret };
+	} else {
+		return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	}
 }
 
 #if defined(DEBUG)
@@ -85,6 +90,7 @@
 	BOOL equal = [otherData.name isEqualToString:_name];
 	equal = equal && [otherData.identifier isEqualToString:_identifier];
 	equal = equal && [otherData.secret isEqualToData:_secret];
+	equal = equal && [otherData.activationIdentifier isEqualToString:_activationIdentifier];
 	return equal;
 }
 

--- a/proj-xcode/PowerAuth2/private/PA2PrivateTokenInterfaces.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateTokenInterfaces.h
@@ -22,6 +22,20 @@
 #import "PA2PrivateTokenData.h"
 
 /**
+ The `PowerAuthPrivateTokenStore` protocol extends `PowerAuthTokenStore`
+ with private functions.
+ */
+@protocol PowerAuthPrivateTokenStore <PowerAuthTokenStore>
+@required
+/**
+ Determine whether token can be still used for 
+ */
+- (BOOL) canGenerateHeaderForToken:(nonnull PowerAuthToken*)token;
+
+@end
+
+
+/**
  The category provides a private interface for PowerAuthToken object.
  The header is not available in public library builds (e.g. for CocoaPods)
  */
@@ -36,7 +50,7 @@
  Initializes token with parent store and with its private data. The internal
  reference to store object is weak.
  */
-- (nonnull id) initWithStore:(nonnull id<PowerAuthTokenStore>)store
+- (nonnull id) initWithStore:(nonnull id<PowerAuthPrivateTokenStore>)store
 						data:(nonnull PA2PrivateTokenData*)data;
 
 @end

--- a/proj-xcode/PowerAuth2/private/PA2PrivateTokenKeychainStore.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateTokenKeychainStore.h
@@ -20,6 +20,7 @@
 #import <PowerAuth2/PowerAuthToken.h>
 #import <PowerAuth2/PowerAuthSessionStatusProvider.h>
 
+#import "PA2PrivateTokenInterfaces.h"
 #import "PA2PrivateRemoteTokenProvider.h"
 #import "PA2TokenDataLock.h"
 
@@ -30,9 +31,10 @@
  stores tokens into the IOS keychain. Each created token has its own
  database entry, with using token's name as unique identifier.
  
- The class also implements fetching token from the PA2 server.
+ The class also implements fetching token from the PA2 server if
+ the remote token provider is set in constructor.
  */
-@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthTokenStore>
+@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthPrivateTokenStore>
 
 /**
  A PowerAuth onfiguration object provided during the object initialization.

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF1ED08B2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1ED08A2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m */; };
+		BF1ED08C2840ED3F00D6B380 /* PowerAuth2ForExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF44F272263C3B0F00F3D498 /* PowerAuth2ForExtensions.framework */; };
+		BF1ED0962840F44200D6B380 /* PowerAuth2ForExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1ED08A2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m */; };
+		BF1ED0A12840F4B900D6B380 /* PowerAuth2ForExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF44F309263C403600F3D498 /* PowerAuth2ForExtensions.framework */; };
 		BF44F277263C3B0F00F3D498 /* PowerAuth2ForExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = BF44F275263C3B0F00F3D498 /* PowerAuth2ForExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF44F28C263C3BF400F3D498 /* PA2SessionStatusDataReader.m in Sources */ = {isa = PBXBuildFile; fileRef = BF44F281263C3BF400F3D498 /* PA2SessionStatusDataReader.m */; };
 		BF44F28D263C3BF400F3D498 /* PA2PrivateConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = BF44F282263C3BF400F3D498 /* PA2PrivateConstants.h */; };
@@ -91,7 +95,27 @@
 		BFC1929F27FC69A4001455C1 /* PowerAuthSharingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC1929B27FC69A4001455C1 /* PowerAuthSharingConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		BF1ED08D2840ED3F00D6B380 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BF44F269263C3B0F00F3D498 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BF44F271263C3B0F00F3D498;
+			remoteInfo = PowerAuth2ForExtensions_ios;
+		};
+		BF1ED09E2840F4AC00D6B380 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BF44F269263C3B0F00F3D498 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BF44F2DD263C403600F3D498;
+			remoteInfo = PowerAuth2ForExtensions_tvos;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		BF1ED0882840ED3F00D6B380 /* PowerAuth2ForExtensionsTests_ios.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PowerAuth2ForExtensionsTests_ios.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF1ED08A2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuth2ForExtensionsTests.m; sourceTree = "<group>"; };
+		BF1ED09D2840F44200D6B380 /* PowerAuth2ForExtensionsTests_tvos.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PowerAuth2ForExtensionsTests_tvos.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF44F272263C3B0F00F3D498 /* PowerAuth2ForExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PowerAuth2ForExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF44F275263C3B0F00F3D498 /* PowerAuth2ForExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuth2ForExtensions.h; sourceTree = "<group>"; };
 		BF44F276263C3B0F00F3D498 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -140,6 +164,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		BF1ED0852840ED3F00D6B380 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF1ED08C2840ED3F00D6B380 /* PowerAuth2ForExtensions.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF1ED0972840F44200D6B380 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF1ED0A12840F4B900D6B380 /* PowerAuth2ForExtensions.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF44F26F263C3B0F00F3D498 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -157,11 +197,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BF1ED0892840ED3F00D6B380 /* PowerAuth2ForExtensionsTests */ = {
+			isa = PBXGroup;
+			children = (
+				BF1ED08A2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m */,
+			);
+			path = PowerAuth2ForExtensionsTests;
+			sourceTree = "<group>";
+		};
+		BF1ED0A02840F4B900D6B380 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BF44F268263C3B0F00F3D498 = {
 			isa = PBXGroup;
 			children = (
 				BF44F274263C3B0F00F3D498 /* PowerAuth2ForExtensions */,
+				BF1ED0892840ED3F00D6B380 /* PowerAuth2ForExtensionsTests */,
 				BF44F273263C3B0F00F3D498 /* Products */,
+				BF1ED0A02840F4B900D6B380 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -170,6 +227,8 @@
 			children = (
 				BF44F272263C3B0F00F3D498 /* PowerAuth2ForExtensions.framework */,
 				BF44F309263C403600F3D498 /* PowerAuth2ForExtensions.framework */,
+				BF1ED0882840ED3F00D6B380 /* PowerAuth2ForExtensionsTests_ios.xctest */,
+				BF1ED09D2840F44200D6B380 /* PowerAuth2ForExtensionsTests_tvos.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -324,6 +383,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		BF1ED0872840ED3F00D6B380 /* PowerAuth2ForExtensionsTests_ios */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF1ED0912840ED3F00D6B380 /* Build configuration list for PBXNativeTarget "PowerAuth2ForExtensionsTests_ios" */;
+			buildPhases = (
+				BF1ED0842840ED3F00D6B380 /* Sources */,
+				BF1ED0852840ED3F00D6B380 /* Frameworks */,
+				BF1ED0862840ED3F00D6B380 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BF1ED08E2840ED3F00D6B380 /* PBXTargetDependency */,
+			);
+			name = PowerAuth2ForExtensionsTests_ios;
+			productName = PowerAuth2ForExtensionsTests;
+			productReference = BF1ED0882840ED3F00D6B380 /* PowerAuth2ForExtensionsTests_ios.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		BF1ED0922840F44200D6B380 /* PowerAuth2ForExtensionsTests_tvos */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF1ED09A2840F44200D6B380 /* Build configuration list for PBXNativeTarget "PowerAuth2ForExtensionsTests_tvos" */;
+			buildPhases = (
+				BF1ED0952840F44200D6B380 /* Sources */,
+				BF1ED0972840F44200D6B380 /* Frameworks */,
+				BF1ED0992840F44200D6B380 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BF1ED09F2840F4AC00D6B380 /* PBXTargetDependency */,
+			);
+			name = PowerAuth2ForExtensionsTests_tvos;
+			productName = PowerAuth2ForExtensionsTests;
+			productReference = BF1ED09D2840F44200D6B380 /* PowerAuth2ForExtensionsTests_tvos.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BF44F271263C3B0F00F3D498 /* PowerAuth2ForExtensions_ios */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF44F27A263C3B0F00F3D498 /* Build configuration list for PBXNativeTarget "PowerAuth2ForExtensions_ios" */;
@@ -368,6 +463,9 @@
 			attributes = {
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
+					BF1ED0872840ED3F00D6B380 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					BF44F271263C3B0F00F3D498 = {
 						CreatedOnToolsVersion = 12.4;
 					};
@@ -388,11 +486,27 @@
 			targets = (
 				BF44F271263C3B0F00F3D498 /* PowerAuth2ForExtensions_ios */,
 				BF44F2DD263C403600F3D498 /* PowerAuth2ForExtensions_tvos */,
+				BF1ED0872840ED3F00D6B380 /* PowerAuth2ForExtensionsTests_ios */,
+				BF1ED0922840F44200D6B380 /* PowerAuth2ForExtensionsTests_tvos */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		BF1ED0862840ED3F00D6B380 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF1ED0992840F44200D6B380 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF44F270263C3B0F00F3D498 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -410,6 +524,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		BF1ED0842840ED3F00D6B380 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF1ED08B2840ED3F00D6B380 /* PowerAuth2ForExtensionsTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF1ED0952840F44200D6B380 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF1ED0962840F44200D6B380 /* PowerAuth2ForExtensionsTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF44F26E263C3B0F00F3D498 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -460,7 +590,82 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		BF1ED08E2840ED3F00D6B380 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BF44F271263C3B0F00F3D498 /* PowerAuth2ForExtensions_ios */;
+			targetProxy = BF1ED08D2840ED3F00D6B380 /* PBXContainerItemProxy */;
+		};
+		BF1ED09F2840F4AC00D6B380 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BF44F2DD263C403600F3D498 /* PowerAuth2ForExtensions_tvos */;
+			targetProxy = BF1ED09E2840F4AC00D6B380 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		BF1ED08F2840ED3F00D6B380 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KTT9G859MR;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wultra.lib.PowerAuth2ForExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Debug;
+		};
+		BF1ED0902840ED3F00D6B380 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KTT9G859MR;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wultra.lib.PowerAuth2ForExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Release;
+		};
+		BF1ED09B2840F44200D6B380 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KTT9G859MR;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wultra.lib.PowerAuth2ForExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Debug;
+		};
+		BF1ED09C2840F44200D6B380 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KTT9G859MR;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wultra.lib.PowerAuth2ForExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Release;
+		};
 		BF44F278263C3B0F00F3D498 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -700,6 +905,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		BF1ED0912840ED3F00D6B380 /* Build configuration list for PBXNativeTarget "PowerAuth2ForExtensionsTests_ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF1ED08F2840ED3F00D6B380 /* Debug */,
+				BF1ED0902840ED3F00D6B380 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BF1ED09A2840F44200D6B380 /* Build configuration list for PBXNativeTarget "PowerAuth2ForExtensionsTests_tvos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF1ED09B2840F44200D6B380 /* Debug */,
+				BF1ED09C2840F44200D6B380 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		BF44F26C263C3B0F00F3D498 /* Build configuration list for PBXProject "PowerAuth2ForExtensions" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_iOS.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF1ED0872840ED3F00D6B380"
+               BuildableName = "PowerAuth2ForExtensionsTests.xctest"
+               BlueprintName = "PowerAuth2ForExtensionsTests_ios"
+               ReferencedContainer = "container:PowerAuth2ForExtensions.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2ForExtensions.xcodeproj/xcshareddata/xcschemes/PowerAuth2ForExtensions_tvOS.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF1ED0922840F44200D6B380"
+               BuildableName = "PowerAuth2ForExtensionsTests_tvos.xctest"
+               BlueprintName = "PowerAuth2ForExtensionsTests_tvos"
+               ReferencedContainer = "container:PowerAuth2ForExtensions.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuth2ForExtensions.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuth2ForExtensions.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthExtensionSDK.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthExtensionSDK.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthSessionStatusProvider.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthSessionStatusProvider.h
@@ -65,4 +65,9 @@
  */
 - (BOOL) hasPendingProtocolUpgrade;
 
+/**
+ Read only property contains activation identifier or nil if object has no valid activation.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
+
 @end

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthToken.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthToken.m
@@ -36,6 +36,7 @@
 @implementation PowerAuthToken
 {
 	PA2PrivateTokenData * _tokenData;
+	__weak id<PowerAuthPrivateTokenStore> _tokenStore;
 }
 
 #pragma mark - Public getters
@@ -62,7 +63,7 @@
 
 - (BOOL) canGenerateHeader
 {
-	return _tokenData != nil && _tokenStore.canRequestForAccessToken;
+	return _tokenData != nil && [_tokenStore canGenerateHeaderForToken:self];
 }
 
 #pragma mark - Public methods
@@ -142,7 +143,7 @@
 	return nil;
 }
 
-- (id) initWithStore:(id<PowerAuthTokenStore>)store
+- (id) initWithStore:(id<PowerAuthPrivateTokenStore>)store
 				data:(PA2PrivateTokenData*)data
 {
 	self = [super init];
@@ -151,6 +152,11 @@
 		_tokenData = data;
 	}
 	return self;
+}
+
+- (id<PowerAuthTokenStore>) tokenStore
+{
+	return _tokenStore;
 }
 
 #pragma mark - Debug

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenData.h
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenData.h
@@ -39,6 +39,11 @@
  Token's secret, received from the server.
  */
 @property (nonatomic, strong, nonnull) NSData * secret;
+/**
+ Identifier of activation associated with the token. If nil, then the serialized
+ data is still in old format and needs to be upgraded.
+ */
+@property (nonatomic, strong, nullable) NSString * activationIdentifier;
 
 #pragma mark - Compare
 

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenData.m
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenData.m
@@ -47,6 +47,7 @@
 	PA2PrivateTokenData * result = [[PA2PrivateTokenData alloc] init];
 	result.name		 			= PA2ObjectAs(dict[@"name"], NSString);
 	result.identifier			= PA2ObjectAs(dict[@"id"], NSString);
+	result.activationIdentifier = PA2ObjectAs(dict[@"aid"], NSString);
 	NSString * loadedB64Secret 	= PA2ObjectAs(dict[@"sec"], NSString);
 	NSData * loadedSecret 		= loadedB64Secret ? [[NSData alloc] initWithBase64EncodedString:loadedB64Secret options:0] : nil;
 	if (loadedSecret) {
@@ -63,7 +64,11 @@
 		return nil;
 	}
 	NSString * b64secret = [_secret base64EncodedStringWithOptions:0];
-	return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	if (_activationIdentifier != nil) {
+		return @{ @"name" : _name, @"id" : _identifier, @"aid": _activationIdentifier, @"sec": b64secret };
+	} else {
+		return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	}
 }
 
 #if defined(DEBUG)
@@ -85,6 +90,7 @@
 	BOOL equal = [otherData.name isEqualToString:_name];
 	equal = equal && [otherData.identifier isEqualToString:_identifier];
 	equal = equal && [otherData.secret isEqualToData:_secret];
+	equal = equal && [otherData.activationIdentifier isEqualToString:_activationIdentifier];
 	return equal;
 }
 

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenInterfaces.h
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenInterfaces.h
@@ -22,6 +22,20 @@
 #import "PA2PrivateTokenData.h"
 
 /**
+ The `PowerAuthPrivateTokenStore` protocol extends `PowerAuthTokenStore`
+ with private functions.
+ */
+@protocol PowerAuthPrivateTokenStore <PowerAuthTokenStore>
+@required
+/**
+ Determine whether token can be still used for 
+ */
+- (BOOL) canGenerateHeaderForToken:(nonnull PowerAuthToken*)token;
+
+@end
+
+
+/**
  The category provides a private interface for PowerAuthToken object.
  The header is not available in public library builds (e.g. for CocoaPods)
  */
@@ -36,7 +50,7 @@
  Initializes token with parent store and with its private data. The internal
  reference to store object is weak.
  */
-- (nonnull id) initWithStore:(nonnull id<PowerAuthTokenStore>)store
+- (nonnull id) initWithStore:(nonnull id<PowerAuthPrivateTokenStore>)store
 						data:(nonnull PA2PrivateTokenData*)data;
 
 @end

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenKeychainStore.h
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2PrivateTokenKeychainStore.h
@@ -20,6 +20,7 @@
 #import <PowerAuth2ForExtensions/PowerAuthToken.h>
 #import <PowerAuth2ForExtensions/PowerAuthSessionStatusProvider.h>
 
+#import "PA2PrivateTokenInterfaces.h"
 #import "PA2PrivateRemoteTokenProvider.h"
 #import "PA2TokenDataLock.h"
 
@@ -30,9 +31,10 @@
  stores tokens into the IOS keychain. Each created token has its own
  database entry, with using token's name as unique identifier.
  
- The class also implements fetching token from the PA2 server.
+ The class also implements fetching token from the PA2 server if
+ the remote token provider is set in constructor.
  */
-@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthTokenStore>
+@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthPrivateTokenStore>
 
 /**
  A PowerAuth onfiguration object provided during the object initialization.

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2SessionStatusDataReader.h
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2SessionStatusDataReader.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 #import <PowerAuth2ForExtensions/PowerAuthMacros.h>
 
 /**
- Returns YES if provided data contains a possible activation.
+ Returns activation identifier in case that data contains a valid activation.
  */
-PA2_EXTERN_C BOOL PA2SessionStatusDataReader_DataContainsActivation(NSData * data);
+PA2_EXTERN_C NSString * PA2SessionStatusDataReader_GetActivationId(NSData * data);

--- a/proj-xcode/PowerAuth2ForExtensions/private/PA2SessionStatusDataReader.m
+++ b/proj-xcode/PowerAuth2ForExtensions/private/PA2SessionStatusDataReader.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,74 +16,189 @@
 
 #import "PA2SessionStatusDataReader.h"
 
-const uint8_t TAG1 = 'P';
-const uint8_t TAG2 = 'A';
+// MARK: - Private implementation
 
-const uint8_t PD_TAG = 'P';
-const uint8_t PD_VER_MIN = '3';
+/**
+ The PDReader structure helps to deserialize informations from the persisted
+ activation data.
+ */
+typedef struct PDReader {
+    const uint8_t * bytes;
+    NSUInteger      length;
+    NSUInteger      offset;
+    BOOL            failure;
+} PDReader;
+
+/**
+ Initialize persistent data stream reader with provided bytes and the length of bytes.
+ */
+static BOOL PDR_init(PDReader * r, const uint8_t * bytes, NSUInteger length)
+{
+    if (!bytes || !length) {
+        return NO;
+    }
+    r->bytes = bytes;
+    r->length = length;
+    r->offset = 0;
+    r->failure = NO;
+    return YES;
+}
+
+/**
+ Get remaining bytes in the byte stream.
+ */
+static NSUInteger PDR_remaining(PDReader * r)
+{
+    return !r->failure ? r->length - r->offset : 0;
+}
+
+/**
+ Determine whether we can read required amount of bytes from the byte stream.
+ */
+static BOOL PDR_canRead(PDReader * r, NSUInteger length)
+{
+    return PDR_remaining(r) >= length;
+}
+
+/**
+ Get one byte from the byte stream.
+ */
+static uint8_t PDR_getByte(PDReader * r)
+{
+    if (PDR_canRead(r, 1)) {
+        return r->bytes[r->offset++];
+    }
+    r->failure = YES;
+    return 0;
+}
+
+/**
+ Copy required amount of bytes to outBytes pointer.
+ */
+static BOOL PDR_getMemory(PDReader * r, void * outBytes, NSUInteger outBytesLength)
+{
+    if (PDR_canRead(r, outBytesLength)) {
+        memcpy(outBytes, r->bytes + r->offset, outBytesLength);
+        r->offset += outBytesLength;
+        return YES;
+    }
+    r->failure = YES;
+    return NO;
+}
+
+/**
+ Skip desired amount of bytes.
+ */
+static BOOL PDR_skip(PDReader * r, NSUInteger size)
+{
+    if (PDR_canRead(r, size)) {
+        r->offset += size;
+        return YES;
+    }
+    r->failure = YES;
+    return NO;
+}
+
+/**
+ Read value representing a count from the byte stream. This function is
+ equivalent to DataReader::readCount() available in C++ impl.
+ */
+static NSUInteger PDR_getCount(PDReader * r)
+{
+    uint8_t tmp[4];
+    tmp[0] = PDR_getByte(r);
+    uint8_t marker = tmp[0] & 0xC0;
+    if (marker == 0x00 || marker == 0x40) {
+        // just one byte
+        return tmp[0];
+    }
+    // marker is 2 or 3, that means that we need 1 or 3 more bytes
+    NSUInteger additional_bytes = marker == 0xC0 ? 3 : 1;
+    if (!PDR_getMemory(r, &tmp[1], additional_bytes)) {
+        return 0;
+    }
+    if (marker == 0xC0) {
+        // 4 bytes
+        return (((NSUInteger)(tmp[0] & 0x3F)) << 24) |
+               (((NSUInteger)(tmp[1]       )) << 16) |
+               (((NSUInteger)(tmp[2]       )) << 8 ) |
+                 (NSUInteger)(tmp[3]);
+        //
+    } else {
+        // 2 bytes
+        return (((NSUInteger)(tmp[0] & 0x3F)) << 8 ) |
+                 (NSUInteger)(tmp[1]);
+        //
+    }
+}
+
+const uint8_t PD_MAGIC1 = 'P';
+const uint8_t PD_MAGIC2 = 'A';
+
+const uint8_t PD_TAG     = 'P';
+const uint8_t PD_VER2    = '3';
+const uint8_t PD_VER3    = '4';
 const uint8_t PD_VER_MAX = '6';
 
-static BOOL _InvestigateSerializedData(const uint8_t * bytes, NSUInteger length)
+/**
+ Function extracts activation identifier from the serialized activation data.
+ */
+static NSString * _ExtractActivationId(const uint8_t * bytes, NSUInteger length)
 {
-	if (length < 3 || !bytes) {
-		return NO;	// very short...
-	}
-	if (bytes[0] != TAG1 || bytes[1] != TAG2) {
-		return NO;	// wrong data magic
-	}
-	uint8_t st = bytes[2];
-	if (st == 0x00) {
-		return NO;	// no activation
-	}
-	if ((st & 0x02) == 0 || length < 192) {
-		return NO;	// invalid active flag, or too short
-	}
-	// The new data format has another version header just after that status byte
-	if (bytes[3] != PD_TAG || bytes[4] < PD_VER_MIN || bytes[4] > PD_VER_MAX) {
-		return NO;	// persistent data tag & ver is wrong
-	}
-	// Data has a possible valid activation
-	return YES;
+    PDReader r;
+    if (!PDR_init(&r, bytes, length)) {
+        return nil;
+    }
+    // Process data header. The format is simple:
+    //  - 'P', 'A', state
+    // Where state is byte that contains 0x02 in case that the data blob contains
+    // the activation data.
+    if (PDR_getByte(&r) != PD_MAGIC1 || PDR_getByte(&r) != PD_MAGIC2) {
+        return nil;
+    }
+    uint8_t state = PDR_getByte(&r);
+    if (state == 0x00) {
+        return nil; // Failure, or no activation
+    }
+    if ((state & 0x02) == 0) {
+        return nil; // Invalid activation flag
+    }
+    
+    // Process activation data. The format differs whether it's Protocol_V2 or V3:
+    // Protocol V2
+    //  - 'P', '3', UInt64 counter, [activationId] ...
+    // Protocol V3
+    //  - 'P', Char version, [hashCounter], [activationId] ...
+    //    where version is '4' up to '6'
+    //          hashCounter is 16 bytes serialzied as ByteArray (e.g. contains counter + data)
+    
+    if (PDR_getByte(&r) != PD_TAG) {
+        return nil; // Invalid tag
+    }
+    uint8_t ver = PDR_getByte(&r);
+    if (ver < PD_VER2 || ver > PD_VER_MAX) {
+        return nil; // Invalid PD version
+    }
+    
+    // Skip 16 bytes of hash counter for Protocol_V3 or 64 bit counter for V2.
+    NSUInteger skipCount = ver >= PD_VER3 ? 1 + 16 : 8;
+    if (!PDR_skip(&r, skipCount)) {
+        return nil;
+    }
+    
+    // Finally, extract an activation identifier.
+    NSUInteger stringLength = PDR_getCount(&r);
+    NSMutableData * stringData = [NSMutableData dataWithLength:stringLength];
+    if (!PDR_getMemory(&r, stringData.mutableBytes, stringData.length)) {
+        return nil;
+    }
+    return [[NSString alloc] initWithData:stringData encoding:NSUTF8StringEncoding];
 }
 
-// DATA_MIGRATION_TAG
-//  .. extension still has to be able to investigate an old data format
-const uint8_t TAG3_OLD = 'M';
-static BOOL _InvestigateOldSerializedData(const uint8_t * bytes, NSUInteger length)
-{
-	// Empty data: 50 41 4D 32 69 FF (PAM2i + 0xFF or PAM2a.... + 0xFF)
-	if (length < 6 || !bytes) {
-		return NO;
-	}
-	if (bytes[0] != TAG1 || bytes[1] != TAG2 || bytes[2] != TAG3_OLD) {
-		return NO;	// wrong data magic
-	}
-	uint8_t ver = bytes[3], st = bytes[4];
-	if ((ver != '1' && ver != '2') || (st != 'a' && st != 'i')) {
-		return NO;	// wrong version or status tag
-	}
-	if (bytes[length - 1] != 0xff) {
-		return NO;	// Wrong terminator
-	}
-	if (st == 'a') {
-		// tag is "active", so we don't want to read a full data, so the possible activation
-		// is depending on length of data.
-		return length > 192;
-	}
-	// Has 'i' tag, and that means no-activation
-	return NO;
-}
 
-BOOL PA2SessionStatusDataReader_DataContainsActivation(NSData * data)
+// MARK: - Public functions
+
+NSString * PA2SessionStatusDataReader_GetActivationId(NSData * data)
 {
-	if (!data) {
-		return NO;
-	}
-	NSUInteger length = data.length;
-	const uint8_t * bytes = (const uint8_t *)data.bytes;
-	// DATA_MIGRATION_TAG
-	if (_InvestigateOldSerializedData(bytes, length)) {
-		return YES;
-	}
-	return _InvestigateSerializedData(bytes, length);
+    return _ExtractActivationId((const uint8_t *)data.bytes, data.length);
 }

--- a/proj-xcode/PowerAuth2ForExtensionsTests/PowerAuth2ForExtensionsTests.m
+++ b/proj-xcode/PowerAuth2ForExtensionsTests/PowerAuth2ForExtensionsTests.m
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "PA2SessionStatusDataReader.h"
+
+@interface PowerAuth2ForExtensionsTests : XCTestCase
+@end
+
+@implementation PowerAuth2ForExtensionsTests
+
+- (void) testActivationIdExtraction
+{
+    // V2 data
+    NSString * serializedDataV2 = @"UEECUDMAAAAAAAACChtGVUxMLUJVVC1GQUtFLUFDVElWQVRJT04tSUQAACcQEFxD134A7"
+                                  @"jgrfXqjmzRSNEoQ+WilNdYscLQ/pbrYJqh9bhDqVVY8lLy2ZvMAtpwZwGrtEGAsKs9Rh8"
+                                  @"mZL1u+aQ3kdsgQKe2HE5aMUP+3mc0Zgzo1XSEC+N8Q8lTW59BH/5x6H+eahxi9n7A4ajz"
+                                  @"LgtaC3tTJhD8AMA3jUBawHBE2zowK9ThJL4kCPJPfzZVEcZhh6v1+IrQybj5WeD2HhFLw"
+                                  @"EJr1nHvmSQAAAAA=";
+    NSData * dataV2 = [[NSData alloc] initWithBase64EncodedString:serializedDataV2 options:0];
+    XCTAssertNotNil(dataV2);
+    NSString * activationIdV2 = PA2SessionStatusDataReader_GetActivationId(dataV2);
+    XCTAssertEqualObjects(@"FULL-BUT-FAKE-ACTIVATION-ID", activationIdV2);
+    
+    // V3 data
+    NSString * serializedDataV3 = @"UEECUDQQcXKzF7KLEfVzcb6F7dQ2jhtGVUxMLUJVVC1GQUtFLUFDVElWQVRJT04tSUQAACcQEFx"
+                                  @"D134A7jgrfXqjmzRSNEoQ+WilNdYscLQ/pbrYJqh9bhDqVVY8lLy2ZvMAtpwZwGrtEGAsKs9Rh8"
+                                  @"mZL1u+aQ3kdsgQKe2HE5aMUP+3mc0Zgzo1XSEC+N8Q8lTW59BH/5x6H+eahxi9n7A4ajzLgtaC3"
+                                  @"tTJhD8AMA3jUBawHBE2zowK9ThJL4kCPJPfzZVEcZhh6v1+IrQybj5WeD2HhFLwEJr1nHvmSQAA"
+                                  @"AAA=";
+    NSData * dataV3 = [[NSData alloc] initWithBase64EncodedString:serializedDataV3 options:0];
+    XCTAssertNotNil(dataV3);
+    NSString * activationIdV3 = PA2SessionStatusDataReader_GetActivationId(dataV3);
+    XCTAssertEqualObjects(@"FULL-BUT-FAKE-ACTIVATION-ID", activationIdV3);
+    
+    // V4, V5 data
+    NSString * serializedDataV4 = @"UEECUDUQcXKzF7KLEfVzcb6F7dQ2jhtGVUxMLUJVVC1GQUtFLUFDVElWQVRJT04tSUQAA"
+                                  @"CcQEFxD134A7jgrfXqjmzRSNEoQ+WilNdYscLQ/pbrYJqh9bhDqVVY8lLy2ZvMAtpwZwG"
+                                  @"rtEGAsKs9Rh8mZL1u+aQ3kdsgQKe2HE5aMUP+3mc0Zgzo1XSEC+N8Q8lTW59BH/5x6H+e"
+                                  @"ahxi9n7A4ajzLgtaC3tTJhD8AMA3jUBawHBE2zowK9ThJL4kCPJPfzZVEcZhh6v1+IrQy"
+                                  @"bj5WeD2HhFLwEJr1nHvmSQAAAAAA";
+    NSData * dataV4 = [[NSData alloc] initWithBase64EncodedString:serializedDataV4 options:0];
+    XCTAssertNotNil(dataV4);
+    NSString * activationIdV4 = PA2SessionStatusDataReader_GetActivationId(dataV4);
+    XCTAssertEqualObjects(@"FULL-BUT-FAKE-ACTIVATION-ID", activationIdV4);
+    
+    // V6 data
+    NSString * serializedDataV6 = @"UEECUDYQf14TA2IN0N6VoDJBjilDQiRkNGE3ZjcyMy0wYjVkLTRkNmYtYjUyMS0yNWUwOTUxO"
+                                  @"TVjZGQAACcQEK2Ay+gcAT"@"0myjKGsC+zBRQQVoUVjmQJ2QPYnmurcQglvhCFZN4BPPLGGYs"
+                                  @"3WGQWPsUwABBdozK+8+yg8a0j5VHZ3hG0QQTYhwy+miVeI2RQL3bKcIggp02t6w6bQo5GrO4z"
+                                  @"LBJeNUTk3S2rF87fT2Cw8jf4f1E+u0D4hBFdrzuXF7gMyPIbIQKoHBeEqkdBXw5DwmEtJ/PQi"
+                                  @"tb3PFDhNh3cs93m3ugZ/jD2xuXr14Akc3Tzea8DDKfGARXHl/rPI/sce31zaQac9ERngH8nhB"
+                                  @"ZKLmYqgzfYEvwAAAQAAAA=";
+    NSData * dataV6 = [[NSData alloc] initWithBase64EncodedString:serializedDataV6 options:0];
+    XCTAssertNotNil(dataV6);
+    NSString * activationIdV6 = PA2SessionStatusDataReader_GetActivationId(dataV6);
+    XCTAssertEqualObjects(@"d4a7f723-0b5d-4d6f-b521-25e095195cdd", activationIdV6);
+}
+
+@end

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuth2ForWatch.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuth2ForWatch.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h
@@ -65,4 +65,9 @@
  */
 - (BOOL) hasPendingProtocolUpgrade;
 
+/**
+ Read only property contains activation identifier or nil if object has no valid activation.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
+
 @end

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthToken.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthToken.m
@@ -36,6 +36,7 @@
 @implementation PowerAuthToken
 {
 	PA2PrivateTokenData * _tokenData;
+	__weak id<PowerAuthPrivateTokenStore> _tokenStore;
 }
 
 #pragma mark - Public getters
@@ -62,7 +63,7 @@
 
 - (BOOL) canGenerateHeader
 {
-	return _tokenData != nil && _tokenStore.canRequestForAccessToken;
+	return _tokenData != nil && [_tokenStore canGenerateHeaderForToken:self];
 }
 
 #pragma mark - Public methods
@@ -142,7 +143,7 @@
 	return nil;
 }
 
-- (id) initWithStore:(id<PowerAuthTokenStore>)store
+- (id) initWithStore:(id<PowerAuthPrivateTokenStore>)store
 				data:(PA2PrivateTokenData*)data
 {
 	self = [super init];
@@ -151,6 +152,11 @@
 		_tokenData = data;
 	}
 	return self;
+}
+
+- (id<PowerAuthTokenStore>) tokenStore
+{
+	return _tokenStore;
 }
 
 #pragma mark - Debug

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.h
@@ -39,8 +39,10 @@
 /**
  Contains activationId if counterpart session object on iPhone has a valid activation or nil if there's no
  such activation.
+ 
+ The property is deprecated, please use `activationIdentifier` as a replacement.
  */
-@property (nonatomic, strong, nullable, readonly) NSString * activationId;
+@property (nonatomic, strong, nullable, readonly) NSString * activationId PA2_DEPRECATED(1.7.0);
 
 /**
  A designated initializer.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthWatchSDK.m
@@ -77,6 +77,11 @@
 	return [[PA2WatchSynchronizationService sharedInstance] activationIdForSessionInstanceId:_configuration.instanceId];
 }
 
+- (NSString*) activationIdentifier
+{
+    return [[PA2WatchSynchronizationService sharedInstance] activationIdForSessionInstanceId:_configuration.instanceId];
+}
+
 
 #pragma mark - PA2SessionStatusProvider implementation
 
@@ -92,7 +97,7 @@
 
 - (BOOL) hasValidActivation
 {
-	return self.activationId != nil;
+	return self.activationIdentifier != nil;
 }
 
 - (BOOL) hasPendingProtocolUpgrade

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenData.h
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenData.h
@@ -39,6 +39,11 @@
  Token's secret, received from the server.
  */
 @property (nonatomic, strong, nonnull) NSData * secret;
+/**
+ Identifier of activation associated with the token. If nil, then the serialized
+ data is still in old format and needs to be upgraded.
+ */
+@property (nonatomic, strong, nullable) NSString * activationIdentifier;
 
 #pragma mark - Compare
 

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenData.m
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenData.m
@@ -47,6 +47,7 @@
 	PA2PrivateTokenData * result = [[PA2PrivateTokenData alloc] init];
 	result.name		 			= PA2ObjectAs(dict[@"name"], NSString);
 	result.identifier			= PA2ObjectAs(dict[@"id"], NSString);
+	result.activationIdentifier = PA2ObjectAs(dict[@"aid"], NSString);
 	NSString * loadedB64Secret 	= PA2ObjectAs(dict[@"sec"], NSString);
 	NSData * loadedSecret 		= loadedB64Secret ? [[NSData alloc] initWithBase64EncodedString:loadedB64Secret options:0] : nil;
 	if (loadedSecret) {
@@ -63,7 +64,11 @@
 		return nil;
 	}
 	NSString * b64secret = [_secret base64EncodedStringWithOptions:0];
-	return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	if (_activationIdentifier != nil) {
+		return @{ @"name" : _name, @"id" : _identifier, @"aid": _activationIdentifier, @"sec": b64secret };
+	} else {
+		return @{ @"name" : _name, @"id" : _identifier, @"sec": b64secret };
+	}
 }
 
 #if defined(DEBUG)
@@ -85,6 +90,7 @@
 	BOOL equal = [otherData.name isEqualToString:_name];
 	equal = equal && [otherData.identifier isEqualToString:_identifier];
 	equal = equal && [otherData.secret isEqualToData:_secret];
+	equal = equal && [otherData.activationIdentifier isEqualToString:_activationIdentifier];
 	return equal;
 }
 

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
@@ -22,6 +22,20 @@
 #import "PA2PrivateTokenData.h"
 
 /**
+ The `PowerAuthPrivateTokenStore` protocol extends `PowerAuthTokenStore`
+ with private functions.
+ */
+@protocol PowerAuthPrivateTokenStore <PowerAuthTokenStore>
+@required
+/**
+ Determine whether token can be still used for 
+ */
+- (BOOL) canGenerateHeaderForToken:(nonnull PowerAuthToken*)token;
+
+@end
+
+
+/**
  The category provides a private interface for PowerAuthToken object.
  The header is not available in public library builds (e.g. for CocoaPods)
  */
@@ -36,7 +50,7 @@
  Initializes token with parent store and with its private data. The internal
  reference to store object is weak.
  */
-- (nonnull id) initWithStore:(nonnull id<PowerAuthTokenStore>)store
+- (nonnull id) initWithStore:(nonnull id<PowerAuthPrivateTokenStore>)store
 						data:(nonnull PA2PrivateTokenData*)data;
 
 @end

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.h
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.h
@@ -20,6 +20,7 @@
 #import <PowerAuth2ForWatch/PowerAuthToken.h>
 #import <PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h>
 
+#import "PA2PrivateTokenInterfaces.h"
 #import "PA2PrivateRemoteTokenProvider.h"
 #import "PA2TokenDataLock.h"
 
@@ -30,9 +31,10 @@
  stores tokens into the IOS keychain. Each created token has its own
  database entry, with using token's name as unique identifier.
  
- The class also implements fetching token from the PA2 server.
+ The class also implements fetching token from the PA2 server if
+ the remote token provider is set in constructor.
  */
-@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthTokenStore>
+@interface PA2PrivateTokenKeychainStore : NSObject<PowerAuthPrivateTokenStore>
 
 /**
  A PowerAuth onfiguration object provided during the object initialization.

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2WatchRemoteTokenProvider.h
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2WatchRemoteTokenProvider.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2WatchRemoteTokenProvider.m
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2WatchRemoteTokenProvider.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
+++ b/proj-xcode/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proj-xcode/PowerAuth2ForWatch/private/PowerAuthWCSessionManager_WatchServices.m
+++ b/proj-xcode/PowerAuth2ForWatch/private/PowerAuthWCSessionManager_WatchServices.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR fixes #188 - a very old issue with possible inconsistency between token store and an activation state. The goal was to add activation identifier into private token data serialized to the persistent storage. Later, we can test whether the activationID is still the same as the current activation's identifier.

To deal with an old data, the implementation on each platform automatically add missing activation-ID and re-save the token data in such case. 

At first look this is a big change, but you can review it on per-commit basis. I tried to split the fix into per-platform commits. On top of that, main iOS SDK, watchOS and extensions SDK share a lot of common token-related code.