### PR TITLE
Issues/435 async operation crash

### DIFF
--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
@@ -969,4 +969,29 @@
 	XCTAssertTrue([_helper checkForPassword:activation.credentials.usePassword]);
 }
 
+- (void) testCancelEnqueuedHttpOperation
+{
+	CHECK_TEST_CONFIG();
+	
+	//
+	// This test validates whether cancelation of enqueued, but not executed yet
+	// HTTP request doesn't lead to crash. See bug #435 for more details.
+	//
+	
+	PowerAuthSdkActivation * activation = [_helper createActivation:YES];
+	if (!activation) {
+		return;
+	}
+	[AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+		[_sdk validatePasswordCorrect:activation.credentials.usePassword callback:^(NSError * _Nullable error) {
+			XCTAssertNil(error);
+			[waiting reportCompletion:nil];
+		}];
+		id<PowerAuthOperationTask> task = [_sdk validatePasswordCorrect:activation.credentials.usePassword callback:^(NSError * _Nullable error) {
+			XCTFail();
+		}];
+		[task cancel];
+	}];
+}
+
 @end

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/AsyncHelper.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/AsyncHelper.h
@@ -77,4 +77,30 @@
  */
 + (void) waitForNextSecond;
 
+/**
+ Function wait for multiple queues to complete.
+ */
++ (void) waitForQueuesCompletion:(NSArray<NSOperationQueue*>*)queues;
+
+@end
+
+/**
+ The AtomicCounter class implements simple atomic counter that may be useful
+ in various tests.
+ */
+@interface AtomicCounter : NSObject
+/**
+ Increment counter and return the current value.
+ */
+- (int32_t) increment;
+/**
+ Increment counter and if limit is reached, then call block.
+ */
+- (int32_t) incrementUpTo:(int32_t)limit
+			   completion:(void(^)(void))block;
+/**
+ The current value of the counter.
+ */
+@property (nonatomic, readonly) int32_t value;
+
 @end

--- a/proj-xcode/PowerAuth2Tests/PA2WeakArrayTests.m
+++ b/proj-xcode/PowerAuth2Tests/PA2WeakArrayTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 #import "PA2WeakArray.h"
 #import "PA2AsyncOperation.h"
+#import "AsyncHelper.h"
 
 @interface PA2WeakArrayTests : XCTestCase
 @end
@@ -34,12 +35,13 @@
 {
 	_queue = [[NSOperationQueue alloc] init];
 	_queue.maxConcurrentOperationCount = 4;
+	_queue.name = [self.class description];
 }
 
 - (void)tearDown
 {
 	[_queue cancelAllOperations];
-	[_queue waitUntilAllOperationsAreFinished];
+	[AsyncHelper waitForQueuesCompletion:@[_queue]];
 }
 
 - (void) testWeakArrayCleanup
@@ -54,7 +56,7 @@
 		
 		[self captureString:T1 toWeakArray:array forAWhile:0.5];
 		[self captureString:T2 toWeakArray:array forAWhile:0.3];
-		[self captureString:T3 toWeakArray:array forAWhile:1.2];
+		[self captureString:T3 toWeakArray:array forAWhile:0.8];
 
 		XCTAssertTrue([array hasString:T1]);
 		XCTAssertTrue([array hasString:T2]);
@@ -63,7 +65,7 @@
 		NSLog(@"All captured, waiting...");
 	}
 	
-	[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.5]];
+	[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.5]];
 	NSUInteger remainingCount = [array allNonnullObjects].count;
 	XCTAssertEqual(0, remainingCount);
 	


### PR DESCRIPTION
Fixed crash in `PA2AsyncOperation` implementation. 

The crash was caused by setting `isFinished` to `YES` even if the operation was not started by the queue. That happened when the operation was canceled before it was actually started in the queue. This situation is now fixed in new `notifyStop` method. The change also adds a more locking to properties accessed by the `NSOperationQueue`.