### PR TITLE
Add support for custom User-Agent

### DIFF
--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -33,6 +33,15 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
 
 - If you try to request for the same access token but with a different set of factors in `PowerAuthAuthentication`, then the request will fail with `WRONG_PARAMETER` error code.
 
+- PowerAuth mobile SDK is now using custom "User-Agent" for all HTTP requests initiated from the library.
+  - You can see how's user agent string constructed by calling `PowerAuthSystem.getDefaultUserAgent(context)`.
+  - To set the previous networking behavior, you can set `""` (empty string) to userAgent property of PowerAuthClientConfiguration:
+    ```java
+    final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConfiguration.Builder()
+                    .userAgent("")
+                    .build();
+    ``` 
+
 ## iOS & tvOS
 
 - TBA

--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -51,6 +51,10 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
 
 - If you try to request for the same access token but with a different set of factors in `PowerAuthAuthentication`, then the request will fail with `wrongParameter` error code.
 
+- PowerAuth mobile SDK is now using custom "User-Agent" for all HTTP requests initiated from the library.
+  - You can see how's user agent string constructed by reading a new `userAgent` property of `PowerAuthClientConfiguration` object.
+  - To set the previous networking behavior, you can set `nil` 
+
 ## iOS & tvOS App Extensions
 
 - TBA

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1587,7 +1587,7 @@ We don't recommend implementing the `HttpRequestInterceptor` interface on your o
 
 The `PowerAuthClientConfiguration` contains `userAgent` property that allows you to set a custom value for "User-Agent" HTTP request header for all requests initiated by the library:
 
-```swift
+```java
 final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConfiguration.Builder()
                 .userAgent("MyApp/1.0.0")
                 .build();

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1582,3 +1582,17 @@ final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConf
 ```
 
 We don't recommend implementing the `HttpRequestInterceptor` interface on your own. The interface allows you to tweak the requests created in the `PowerAuthSDK` but also gives you an opportunity to break things. So, rather than create your own interceptor, try to contact us and describe what's your problem with the networking in the PowerAuth SDK. Also, keep in mind that the interface may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability of the interface itself.
+
+### Custom User-Agent
+
+The `PowerAuthClientConfiguration` contains `userAgent` property that allows you to set a custom value for "User-Agent" HTTP request header for all requests initiated by the library:
+
+```swift
+final PowerAuthClientConfiguration clientConfiguration = new PowerAuthClientConfiguration.Builder()
+                .userAgent("MyApp/1.0.0")
+                .build();
+```
+
+The default value of the property is composed as "APP-PACKAGE/APP-PACKAGE-VERSION PowerAuth2/PA-VERSION (OS/OS-VERSION, DEVICE-INFO)", for example: "com.test.app/1.0 PowerAuth2/1.7.0 (Android 11.0.0, SM-A525F)".
+
+If you set `""` (empty string) to the `userAgent` property, then the default "User-Agent" provided by the operating system will be used. 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1674,3 +1674,16 @@ clientConfig.requestInterceptors = [ basicAuth, customHeader ]
 ```
 
 We don't recommend implementing the `PowerAuthHttpRequestInterceptor` protocol on your own. The interface allows you to tweak the requests created in the `PowerAuthSDK` but also gives you an opportunity to break things. So, rather than create your own interceptor, contact us and describe what use-case is missing. Also, keep in mind that the interface may change in the future. We can guarantee the API stability of public classes implementing this interface, but not the stability of the interface itself.
+
+### Custom User-Agent
+
+The `PowerAuthClientConfiguration` contains `userAgent` property that allows you to set a custom value for "User-Agent" HTTP request header for all requests initiated by the library:
+
+```swift
+let clientConfig = PowerAuthClientConfiguration()
+clientConfig.userAgent = "MyClient/1.0.0"
+```
+
+The default value of the property is composed as "APP-EXECUTABLE/APP-VERSION PowerAuth2/PA-VERSION (OS/OS-VERSION, DEVICE-INFO)", for example: "MyApp/1.0 PowerAuth2/1.7.0 (iOS 15.2, iPhone12.1)". The information about application executable and version is get from main bundle and its `Info.plist`.
+
+If you set `nil` to the `userAgent` property, then the default "User-Agent" provided by the operating system will be used. 

--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -31,6 +31,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionName VERSION_NAME
         versionCode 1
+        buildConfigField "String", "LIBRARY_VERSION_NAME", "\"" + VERSION_NAME + "\""
 
         vectorDrawables.useSupportLibrary = true
 
@@ -39,7 +40,6 @@ android {
                 abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
             }
         }
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         loadInstrumentationTestConfigProperties(project, owner)
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClientTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClientTask.java
@@ -18,6 +18,8 @@ package io.getlime.security.powerauth.networking.client;
 
 import android.net.TrafficStats;
 import android.os.AsyncTask;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 
 import java.io.ByteArrayOutputStream;
@@ -105,8 +107,9 @@ class HttpClientTask<TRequest, TResponse> extends AsyncTask<TRequest, Void, TRes
         return result.toByteArray();
     }
 
+    @SafeVarargs
     @Override
-    protected TResponse doInBackground(TRequest... tRequests) {
+    protected final TResponse doInBackground(TRequest... tRequests) {
         setThreadStatsTag();
 
         InputStream inputStream = null;
@@ -131,6 +134,9 @@ class HttpClientTask<TRequest, TResponse> extends AsyncTask<TRequest, Void, TRes
             urlConnection.setReadTimeout(clientConfiguration.getReadTimeout());
             for (Map.Entry<String, String> header : requestData.httpHeaders.entrySet()) {
                 urlConnection.setRequestProperty(header.getKey(), header.getValue());
+            }
+            if (!TextUtils.isEmpty(clientConfiguration.getUserAgent())) {
+                urlConnection.setRequestProperty("User-Agent", clientConfiguration.getUserAgent());
             }
 
             // ssl validation strategy

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthClientConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthClientConfiguration.java
@@ -75,6 +75,11 @@ public class PowerAuthClientConfiguration {
     private final List<HttpRequestInterceptor> requestInterceptors;
 
     /**
+     * Property that specifies value for "User-Agent" HTTP request header.
+     */
+    private final String userAgent;
+
+    /**
      * @return connection timeout in milliseconds
      */
     public int getConnectionTimeout() {
@@ -108,6 +113,14 @@ public class PowerAuthClientConfiguration {
     }
 
     /**
+     * @return Value for User-Agent HTTP request header. If {@code ""} (empty string), then the
+     * default system provided value is used in the networking.
+     */
+    public @Nullable String getUserAgent() {
+        return userAgent;
+    }
+
+    /**
      * Default private constructor. Use {@link Builder} to create a new instance of this class.
      *
      * @param connectionTimeout Connection timeout in ms.
@@ -115,18 +128,21 @@ public class PowerAuthClientConfiguration {
      * @param allowUnsecuredConnection Defines whether unsecured connection is allowed.
      * @param clientValidationStrategy {@link HttpClientValidationStrategy} object that implements TLS validation strategy.
      * @param requestInterceptors Array of {@link HttpRequestInterceptor} objects or {@code null} if there's none.
+     * @param userAgent Value for User-Agent HTTP request header or (@code ""} if default, system provided User-Agent should be used.
      */
     private PowerAuthClientConfiguration(
             int connectionTimeout,
             int readTimeout,
             boolean allowUnsecuredConnection,
             HttpClientValidationStrategy clientValidationStrategy,
-            List<HttpRequestInterceptor> requestInterceptors) {
+            List<HttpRequestInterceptor> requestInterceptors,
+            String userAgent) {
         this.connectionTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
         this.allowUnsecuredConnection = allowUnsecuredConnection;
         this.clientValidationStrategy = clientValidationStrategy;
         this.requestInterceptors = requestInterceptors;
+        this.userAgent = userAgent;
     }
 
     /**
@@ -138,6 +154,7 @@ public class PowerAuthClientConfiguration {
         private boolean allowUnsecuredConnection = DEFAULT_ALLOW_UNSECURED_CONNECTION;
         private HttpClientValidationStrategy clientValidationStrategy;
         private ArrayList<HttpRequestInterceptor> requestInterceptors;
+        private String userAgent;
 
         /**
          * Creates a builder for {@link PowerAuthClientConfiguration}.
@@ -198,6 +215,18 @@ public class PowerAuthClientConfiguration {
         }
 
         /**
+         * Adds value for User-Agent HTTP request header.
+         * @param userAgent Value for "User-Agent" HTTP request header. If value is{@code ""}
+         *                 (empty string) then the system provided header is used. If {@code null}
+         *                  is set, then the default value, provided by PowerAuth SDK is used.
+         * @return The same {@link Builder} object instance.
+         */
+        public Builder userAgent(@Nullable String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
+        /**
          * Build a final configuration.
          *
          * @return Final {@link PowerAuthClientConfiguration} instance.
@@ -208,7 +237,32 @@ public class PowerAuthClientConfiguration {
                     readTimeout,
                     allowUnsecuredConnection,
                     clientValidationStrategy,
-                    requestInterceptors != null ? Collections.unmodifiableList(requestInterceptors) : null);
+                    requestInterceptors != null ? Collections.unmodifiableList(requestInterceptors) : null,
+                    userAgent);
         }
+    }
+
+    /**
+     * Create a new instance of {@link PowerAuthClientConfiguration} if this configuration has no
+     * application's provided userAgent. In this casne, the returned instance will contain user agent
+     * set from the parameter. If application set userAgent property in the configuration, then
+     * returns this.
+     *
+     * @param customUserAgent Custom value for userAgent property.
+     * @return {@link PowerAuthClientConfiguration} or {@code this}, depending on whether this structure has
+     * userAgent set.
+     */
+    @NonNull
+    PowerAuthClientConfiguration duplicateIfNoUserAgentIsSet(@NonNull String customUserAgent) {
+        if (userAgent != null) {
+            return this;
+        }
+        return new PowerAuthClientConfiguration(
+                connectionTimeout,
+                readTimeout,
+                allowUnsecuredConnection,
+                clientValidationStrategy,
+                requestInterceptors,
+                customUserAgent);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -224,8 +224,11 @@ public class PowerAuthSDK {
             if (mKeychainConfiguration == null) {
                 mKeychainConfiguration = new PowerAuthKeychainConfiguration.Builder().build();
             }
+            final String defaultUserAgent = PowerAuthSystem.getDefaultUserAgent(context);
             if (mClientConfiguration == null) {
-                mClientConfiguration = new PowerAuthClientConfiguration.Builder().build();
+                mClientConfiguration = new PowerAuthClientConfiguration.Builder().userAgent(defaultUserAgent).build();
+            } else {
+                mClientConfiguration = mClientConfiguration.duplicateIfNoUserAgentIsSet(defaultUserAgent);
             }
             if (mCallbackDispatcher == null) {
                 mCallbackDispatcher = MainThreadExecutor.getInstance();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PowerAuthSystem.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PowerAuthSystem.java
@@ -16,8 +16,13 @@
 
 package io.getlime.security.powerauth.system;
 
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.BuildConfig;
 
 /**
  * Class that provides information about system and runtime.
@@ -48,6 +53,36 @@ public class PowerAuthSystem {
             return capitalizeString(model);
         }
         return capitalizeString(manufacturer) + " " + model;
+    }
+
+    /**
+     * Build default value for "User-Agent" HTTP request header. The value is composed as
+     * "APP-PACKAGE/APP-VERSION PowerAuth2/PA-VERSION (Android OS-VERSION, DEVICE-INFO)", for example:
+     * "com.test.app/1.0 PowerAuth2/1.7.0 (Android 11.0.0, SM-A525F)".
+     * @param context Android context.
+     * @return Default value for User-Agent HTTP request header.
+     */
+    public static @NonNull String getDefaultUserAgent(@NonNull Context context) {
+        // Get basic info about library
+        final String libraryInfo = "PowerAuth2/" + BuildConfig.LIBRARY_VERSION_NAME + " (Android " + Build.VERSION.RELEASE + ", " + getDeviceInfo() + ")";
+        // Get info about application
+        context = context.getApplicationContext();
+        PackageManager pm = context.getPackageManager();
+        String pkgName = context.getPackageName();
+        PackageInfo pkgInfo;
+        try {
+            pkgInfo = pm.getPackageInfo(pkgName, 0);
+        } catch (PackageManager.NameNotFoundException e) {
+            pkgInfo = null;
+        }
+
+        if (pkgInfo != null) {
+            String pkgVer = pkgInfo.versionName;
+            if (pkgVer != null) {
+                return pkgName + "/" + pkgVer + " " + libraryInfo;
+            }
+        }
+        return libraryInfo;
     }
 
     /**

--- a/proj-xcode/PowerAuth2/PowerAuthClientConfiguration.h
+++ b/proj-xcode/PowerAuth2/PowerAuthClientConfiguration.h
@@ -80,6 +80,12 @@
 @property (nonatomic, strong, nullable) NSArray<id<PowerAuthHttpRequestInterceptor>>* requestInterceptors;
 
 /**
+ Property that specifies the content of User-Agent request header. The default is value calculated in `PowerAuthSystem.defaultUserAgent()` function.
+ If you set `nil` to this property, then the default value provided by operating system is used.
+ */
+@property (nonatomic, strong, nullable) NSString * userAgent;
+
+/**
  Return the shared in stance of a client configuration object.
  
  @return Shared instance of a client configuration.

--- a/proj-xcode/PowerAuth2/PowerAuthClientConfiguration.m
+++ b/proj-xcode/PowerAuth2/PowerAuthClientConfiguration.m
@@ -15,6 +15,7 @@
  */
 
 #import <PowerAuth2/PowerAuthClientConfiguration.h>
+#import <PowerAuth2/PowerAuthSystem.h>
 
 @implementation PowerAuthClientConfiguration
 
@@ -22,7 +23,8 @@
 {
 	self = [super init];
 	if (self) {
-		self.defaultRequestTimeout = 20.0;
+		_defaultRequestTimeout = 20.0;
+		_userAgent = [PowerAuthSystem defaultUserAgent];
 	}
 	return self;
 }
@@ -34,6 +36,7 @@
 		c->_defaultRequestTimeout = _defaultRequestTimeout;
 		c->_sslValidationStrategy = _sslValidationStrategy;
 		c->_requestInterceptors = [_requestInterceptors copyWithZone:zone];
+		c->_userAgent = _userAgent;
 	}
 	return c;
 }

--- a/proj-xcode/PowerAuth2/PowerAuthMacros.h
+++ b/proj-xcode/PowerAuth2/PowerAuthMacros.h
@@ -107,3 +107,23 @@
 	#define PA2_HAS_LACONTEXT 0
 	#define LAContext NSObject
 #endif
+
+// SDK modules availability
+#if PA2_HAS_CORE_MODULE
+	// PowerAuth2 module
+	#define PA2_MODULE_MAIN_SDK			1
+	#define PA2_MODULE_WATCH_SDK		0
+	#define PA2_MODULE_APPEXT_SDK		0
+#else
+	#if TARGET_OS_WATCH
+		// PowerAuth2ForWatch module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	1
+		#define PA2_MODULE_APPEXT_SDK	0
+	#else
+		// PowerAuth2ForExtensions module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	0
+		#define PA2_MODULE_APPEXT_SDK	1
+	#endif
+#endif

--- a/proj-xcode/PowerAuth2/PowerAuthSystem.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSystem.h
@@ -38,4 +38,13 @@
  */
 + (nonnull NSString*) deviceInfo;
 
+/**
+ Returns default user agent for internal networking or nil in case that
+ user agent string cannot be provided.
+ 
+ The default string is typically composed as: "%MainBundleVersion% %PowerAuthFrameworkVersion% (%OsVersion%, %DeviceInfo%)".
+ For example: "PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.6.3 (iOS 15.2, iPhone12.3)".
+ */
++ (nullable NSString*) defaultUserAgent;
+
 @end

--- a/proj-xcode/PowerAuth2/private/PA2HttpClient.m
+++ b/proj-xcode/PowerAuth2/private/PA2HttpClient.m
@@ -191,6 +191,9 @@ static void _LogHttpResponse(PA2RestApiEndpoint * endpoint, NSHTTPURLResponse * 
 			[op completeWithResult:nil error:error];
 			return nil;
 		}
+		if (_configuration.userAgent) {
+			[urlRequest addValue:_configuration.userAgent forHTTPHeaderField:@"User-Agent"];
+		}
 		// Process all request interceptors
 		[_configuration.requestInterceptors enumerateObjectsUsingBlock:^(id<PowerAuthHttpRequestInterceptor> interceptor, NSUInteger idx, BOOL * stop) {
 			[interceptor processRequest:urlRequest];

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthMacros.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthMacros.h
@@ -107,3 +107,23 @@
 	#define PA2_HAS_LACONTEXT 0
 	#define LAContext NSObject
 #endif
+
+// SDK modules availability
+#if PA2_HAS_CORE_MODULE
+	// PowerAuth2 module
+	#define PA2_MODULE_MAIN_SDK			1
+	#define PA2_MODULE_WATCH_SDK		0
+	#define PA2_MODULE_APPEXT_SDK		0
+#else
+	#if TARGET_OS_WATCH
+		// PowerAuth2ForWatch module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	1
+		#define PA2_MODULE_APPEXT_SDK	0
+	#else
+		// PowerAuth2ForExtensions module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	0
+		#define PA2_MODULE_APPEXT_SDK	1
+	#endif
+#endif

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthSystem.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthSystem.h
@@ -38,4 +38,13 @@
  */
 + (nonnull NSString*) deviceInfo;
 
+/**
+ Returns default user agent for internal networking or nil in case that
+ user agent string cannot be provided.
+ 
+ The default string is typically composed as: "%MainBundleVersion% %PowerAuthFrameworkVersion% (%OsVersion%, %DeviceInfo%)".
+ For example: "PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.6.3 (iOS 15.2, iPhone12.3)".
+ */
++ (nullable NSString*) defaultUserAgent;
+
 @end

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthMacros.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthMacros.h
@@ -107,3 +107,23 @@
 	#define PA2_HAS_LACONTEXT 0
 	#define LAContext NSObject
 #endif
+
+// SDK modules availability
+#if PA2_HAS_CORE_MODULE
+	// PowerAuth2 module
+	#define PA2_MODULE_MAIN_SDK			1
+	#define PA2_MODULE_WATCH_SDK		0
+	#define PA2_MODULE_APPEXT_SDK		0
+#else
+	#if TARGET_OS_WATCH
+		// PowerAuth2ForWatch module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	1
+		#define PA2_MODULE_APPEXT_SDK	0
+	#else
+		// PowerAuth2ForExtensions module
+		#define PA2_MODULE_MAIN_SDK		0
+		#define PA2_MODULE_WATCH_SDK	0
+		#define PA2_MODULE_APPEXT_SDK	1
+	#endif
+#endif

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthSystem.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthSystem.h
@@ -38,4 +38,13 @@
  */
 + (nonnull NSString*) deviceInfo;
 
+/**
+ Returns default user agent for internal networking or nil in case that
+ user agent string cannot be provided.
+ 
+ The default string is typically composed as: "%MainBundleVersion% %PowerAuthFrameworkVersion% (%OsVersion%, %DeviceInfo%)".
+ For example: "PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.6.3 (iOS 15.2, iPhone12.3)".
+ */
++ (nullable NSString*) defaultUserAgent;
+
 @end

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/AsyncHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/AsyncHelper.m
@@ -119,7 +119,7 @@
 	[self synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
 		[queues enumerateObjectsUsingBlock:^(NSOperationQueue * queue, NSUInteger idx, BOOL * stop) {
 			NSLog(@"AsyncHelper: Waiting for queue %@", queue.name ? queue.name : @"<UNNAMED>");
-			if (@available(iOS 13.0, *)) {
+			if (@available(iOS 13.0, tvOS 13.0, *)) {
 				[queue addBarrierBlock:^{
 					[ctr incrementUpTo:queuesCount completion:^{
 						[waiting reportCompletion:nil];


### PR DESCRIPTION
This PR adds support for application provided User-Agent added to all HTTP requests initiated from the library. The change also defines a default User-Agent string provided by PowerAuth SDK itself, if client configuration is not altered.