### PR TITLE
Android: Fix #406: IOException wrapped into PowerAuthErrorException

### DIFF
--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -42,6 +42,8 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
                     .build();
     ``` 
 
+- `IOException` is no longer reported from SDK's internal networking. Now all such exceptions are wrapped into `PowerAuthErrorException` with `NETWORK_ERROR` code set.
+
 ## iOS & tvOS
 
 - TBA

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClientTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClientTask.java
@@ -36,6 +36,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocketFactory;
 
 import io.getlime.security.powerauth.ecies.EciesEncryptorId;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.networking.exceptions.FailedApiException;
 import io.getlime.security.powerauth.networking.interceptors.HttpRequestInterceptor;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
@@ -162,7 +164,7 @@ class HttpClientTask<TRequest, TResponse> extends AsyncTask<TRequest, Void, TRes
             // Apply request interceptors
             final List<HttpRequestInterceptor> requestInterceptors = clientConfiguration.getRequestInterceptors();
             if (requestInterceptors != null) {
-                for (HttpRequestInterceptor interceptor: requestInterceptors) {
+                for (HttpRequestInterceptor interceptor : requestInterceptors) {
                     interceptor.processRequestConnection(urlConnection);
                 }
             }
@@ -201,6 +203,11 @@ class HttpClientTask<TRequest, TResponse> extends AsyncTask<TRequest, Void, TRes
             logResponse(urlConnection, responseData, null);
             // Finally, return the result.
             return result;
+        } catch (IOException e) {
+            // Log response with error
+            logResponse(urlConnection, null, e);
+            // Create PowerAuthErrorException with NETWORK_ERROR code
+            error = new PowerAuthErrorException(PowerAuthErrorCodes.NETWORK_ERROR, e.getMessage(), e);
 
         } catch (Throwable e) {
             // Log response with error

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/JsonSerialization.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/JsonSerialization.java
@@ -49,11 +49,6 @@ public class JsonSerialization {
     private Gson gson;
 
     /**
-     * Private instance of {@link JsonParser}.
-     */
-    private JsonParser parser;
-
-    /**
      * Constant representing an empty object, serialized to JSON (e.g. empty curly brackets, {@code {}})
      */
     private static final byte[] EMPTY_OBJECT_BYTES = { 0x7B, 0x7D };
@@ -141,7 +136,7 @@ public class JsonSerialization {
             throw new JsonParseException("Empty response received.");
         }
         final String jsonString = new String(data, Charset.defaultCharset());
-        final JsonElement jsonRoot = getParser().parse(jsonString);
+        final JsonElement jsonRoot = JsonParser.parseString(jsonString);
         if (!jsonRoot.isJsonObject()) {
             throw new JsonParseException("Unexpected type of JSON data.");
         }
@@ -179,7 +174,7 @@ public class JsonSerialization {
     public byte[] decryptData(@Nullable byte[] data, @NonNull EciesEncryptor decryptor) throws PowerAuthErrorException {
         // 1. Deserialize bytes into response object
         final EciesEncryptedResponse response = deserializeObject(data, TypeToken.get(EciesEncryptedResponse.class));
-        // 2. Construct cryptogam with data & mac (response doesn't contain ephemeral key)
+        // 2. Construct cryptogram with data & mac (response doesn't contain ephemeral key)
         final EciesCryptogram cryptogram = new EciesCryptogram(response.getEncryptedData(), response.getMac());
         // 3. Decrypt the response
         final byte[] plainData = decryptor.decryptResponse(cryptogram);
@@ -278,16 +273,4 @@ public class JsonSerialization {
         }
         return gson;
     }
-
-    /**
-     * @return Lazy initialized instance of {@link JsonParser} object.
-     */
-    @NonNull
-    public JsonParser getParser() {
-        if (parser == null) {
-            parser = new JsonParser();
-        }
-        return parser;
-    }
-
 }


### PR DESCRIPTION
This PR fixes issue where `IOException` was reported back to application from networking stack used by SDK internally. Now this type of exception is wrapped into `PowerAuthErrorException` with `NETWORK_ERROR` error code.

On top of that, change Fixes deprecated API usage in `JsonSerialization` class.