### PR TITLE
Android: Fix #455: Fixed javadoc generator parameters

### DIFF
--- a/proj-android/PowerAuthLibrary/android-release-aar.gradle
+++ b/proj-android/PowerAuthLibrary/android-release-aar.gradle
@@ -45,7 +45,8 @@ ext {
 
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    // options.addStringOption('Xdoclint:none', '-quiet')
+    // Make generated BuildConfig visible for javadoc
+    source += 'build/generated/source/buildConfig'
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     // adds libraries to classpath
     android.libraryVariants.all { variant ->
@@ -161,6 +162,11 @@ nexusPublishing {
         }
     }
 }
+
+afterEvaluate {
+    androidJavadocs.dependsOn generateReleaseBuildConfig
+}
+
 
 // Helper functions
 

--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -69,7 +69,7 @@ android {
         implementation 'androidx.appcompat:appcompat:1.4.2'
         implementation 'androidx.fragment:fragment:1.4.1'
         implementation 'androidx.biometric:biometric:1.1.0'
-        implementation 'com.google.code.gson:gson:2.8.6'
+        implementation 'com.google.code.gson:gson:2.8.8'
 
         // testing
         androidTestImplementation 'androidx.test:core:1.4.0'
@@ -77,7 +77,7 @@ android {
         androidTestImplementation 'androidx.test:rules:1.4.0'
         androidTestImplementation 'androidx.test.ext:junit:1.1.3'
         androidTestImplementation 'io.getlime.core:rest-model-base:1.2.0'
-        androidTestImplementation 'com.google.code.gson:gson:2.8.6'
+        androidTestImplementation 'com.google.code.gson:gson:2.8.8'
     }
     
     externalNativeBuild {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/HttpRestClient.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/HttpRestClient.java
@@ -48,14 +48,12 @@ public class HttpRestClient {
     private final @NonNull String baseUrl;
     private final @Nullable String authorization;
     private final @NonNull Gson gson;
-    private final @NonNull JsonParser jsonParser;
 
     public HttpRestClient(@NonNull String baseUrl, @Nullable String authorization) {
         // Make sure that baseUrl doesn't end with forward slash.
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
         this.authorization = authorization;
         this.gson = new GsonBuilder().create();
-        this.jsonParser = new JsonParser();
     }
 
     /**
@@ -177,10 +175,9 @@ public class HttpRestClient {
         if (typeToken == null) {
             return null;
         }
-        final TResponse response;
         try {
             final String responseString = new String(responseData.response, Charset.defaultCharset());
-            final JsonElement jsonRoot = jsonParser.parse(responseString);
+            final JsonElement jsonRoot = JsonParser.parseString(responseString);
             if (!jsonRoot.isJsonObject()) {
                 throw new PowerAuthServerApiException("JSON response doesn't contain a response object.");
             }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
@@ -75,6 +75,7 @@ public class GetActivationStatusTask extends GroupedTask<ActivationStatus> {
      * @param session low level {@link Session} object
      * @param sharedLock Shared lock.
      * @param callbackDispatcher callback dispatcher from parent SDK object
+     * @param isUpgradeDisabled If true, then protocol upgrade is disabled
      * @param completionListener final completion listener.
      */
     public GetActivationStatusTask(

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PowerAuthSystem.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PowerAuthSystem.java
@@ -21,7 +21,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.getlime.security.powerauth.BuildConfig;
 
 /**


### PR DESCRIPTION
This PR fixes issue in gradle when library is publishing to local or remote maven. On top of that, it fixes warnings with deprecated API usage (JsonParser)