### PR TITLE
Core: Fix #499: Obfuscate password stored in memory

### DIFF
--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -113,6 +113,10 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
   - You can see how's user agent string constructed by reading a new `userAgent` property of `PowerAuthClientConfiguration` object.
   - To set the previous networking behavior, you can set `nil` 
 
+### Other changes in 1.7.2+
+
+- Changed value returned from `PowerAuthCorePassword.validatePasswordComplexity()` function, includiding the prototype of the validation block. 
+
 ## iOS & tvOS App Extensions
 
 ### API changes

--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -115,7 +115,7 @@ PowerAuth Mobile SDK in version `1.7.0` is a maintenance release that brings mul
 
 ### Other changes in 1.7.2+
 
-- Changed value returned from `PowerAuthCorePassword.validatePasswordComplexity()` function, includiding the prototype of the validation block. 
+- Changed value returned from `PowerAuthCorePassword.validatePasswordComplexity()` function, including the prototype of the validation block. 
 
 ## iOS & tvOS App Extensions
 

--- a/include/PowerAuth/Password.h
+++ b/include/PowerAuth/Password.h
@@ -75,9 +75,9 @@ namespace powerAuth
         size_t length() const;
         
         /**
-         Returns reference to plaintext password data.
+         Returns copy of plaintext password data.
          */
-        const cc7::ByteArray & passwordData() const;
+        cc7::ByteArray passwordData() const;
         
         /**
          Returns true when both objects contains equal passphrase.
@@ -128,7 +128,10 @@ namespace powerAuth
         typedef std::vector<size_t> PosVector;
         
         /**
-         Passphrase
+         Buffer with passphrase, where first `randomKeySize` bytes represents
+         a key for simple XOR cipher. The rest of the _pass array
+         contains actual password XOR'ed with the key. See `inplaceXor()`
+         function for more details.
          */
         cc7::ByteArray  _pass;
         
@@ -149,12 +152,20 @@ namespace powerAuth
          */
         void updateIndexes(size_t begin, ptrdiff_t offset);
         
+        // MARK: Password protection
+        
+        /**
+         Size of key for XOR function.
+         */
+        const size_t randomKeySize = 16;
+        
+        /**
+         Modify _pass buffer from begin position to the end of the buffer,
+         by xoring with appropriate value from range <0, randomKeySize).
+         */
+        void inplaceXor(size_t begin);
     };
-    
-    
-    
 
-    
 } // io::getlime::powerAuth
 } // io::getlime
 } // io

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/core/PasswordTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/core/PasswordTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class PasswordTest {
+
+    @Test
+    public void testImmutablePassword() {
+        Password p1 = new Password("HelloWorld");
+        assertFalse(p1.isMutable());
+        assertEquals(10, p1.length());
+        assertEquals("HelloWorld", extractStringFromPassword(p1));
+        assertFalse(p1.clear());
+        assertEquals(10, p1.length());
+
+        Password p2 = new Password("HelloWorld");
+        assertTrue(p1.isEqualToPassword(p2));
+
+        p1.destroy();
+        assertFalse(p1.isEqualToPassword(p2));
+        p2.destroy();
+        assertFalse(p1.isEqualToPassword(p2));
+
+        Password p3 = new Password(new byte[] { 1, 2, 3, 4, 5, 6, 7 });
+        assertFalse(p3.isMutable());
+        assertEquals(7, p3.length());
+        assertArrayEquals(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, extractBytesFromPassword(p3));
+
+        p3.destroy();
+        assertEquals(0, p3.length());
+    }
+
+    @Test
+    public void testMutableNumbers() {
+        Password p1 = new Password();
+        assertTrue(p1.isMutable());
+        assertEquals(0, p1.length());
+
+        assertTrue(p1.addCharacter(1));
+        assertTrue(p1.insertCharacter(3, 1));
+        assertTrue(p1.insertCharacter(0, 0));
+        assertTrue(p1.insertCharacter(2, 2));
+        assertTrue(p1.addCharacter(4));
+        assertEquals(5, p1.length());
+        assertEquals(new Password(new byte[] { 0, 1, 2, 3, 4}), p1);
+
+        assertTrue(p1.removeCharacter(0));
+        assertEquals(new Password(new byte[] { 1, 2, 3, 4}), p1);
+        assertTrue(p1.removeCharacter(1));
+        assertEquals(new Password(new byte[] { 1, 3, 4}), p1);
+        assertTrue(p1.removeCharacter(2));
+        assertEquals(new Password(new byte[] { 1, 3}), p1);
+        assertTrue(p1.removeLastCharacter());
+        assertTrue(p1.removeLastCharacter());
+
+        // Out of range access
+        assertFalse(p1.removeLastCharacter());
+        assertFalse(p1.removeCharacter(0));
+        assertFalse(p1.removeCharacter(1));
+        assertFalse(p1.insertCharacter(11, 1));
+
+        assertEquals(0, p1.length());
+        assertTrue(p1.addCharacter(5));
+        assertEquals(1, p1.length());
+
+        assertTrue(p1.clear());
+        assertEquals(0, p1.length());
+
+        p1.destroy();
+        assertEquals(0, p1.length());
+        try {
+            p1.validatePasswordComplexity(passwordBytes -> 0);
+            fail();
+        } catch (IllegalStateException exception) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testMutableUnicode() {
+        Password p1 = new Password();
+        assertTrue(p1.isMutable());
+
+        assertTrue(p1.addCharacter('e'));
+        assertTrue(p1.addCharacter('l'));
+        assertTrue(p1.insertCharacter('l', 1));
+        assertTrue(p1.insertCharacter('o', 3));
+        assertTrue(p1.addCharacter('W'));
+        assertTrue(p1.addCharacter('0'));
+        assertTrue(p1.addCharacter('r'));
+        assertTrue(p1.addCharacter('l'));
+        assertTrue(p1.addCharacter('d'));
+        assertTrue(p1.insertCharacter(0x397, 0));
+        assertEquals(10, p1.length());
+        assertEquals(11, extractBytesFromPassword(p1).length);
+        assertEquals("ΗelloW0rld", extractStringFromPassword(p1));
+
+        assertTrue(p1.removeCharacter(0));
+        assertEquals("elloW0rld", extractStringFromPassword(p1));
+        assertTrue(p1.removeLastCharacter());
+        assertEquals("elloW0rl", extractStringFromPassword(p1));
+        assertTrue(p1.insertCharacter(0x206, 1));
+        assertEquals("eȆlloW0rl", extractStringFromPassword(p1));
+        assertEquals(9, p1.length());
+        assertTrue(p1.removeCharacter(5));
+        assertEquals("eȆllo0rl", extractStringFromPassword(p1));
+        assertTrue(p1.removeCharacter(1));
+        assertEquals("ello0rl", extractStringFromPassword(p1));
+
+        p1.destroy();
+        assertEquals(0, p1.length());
+        try {
+            p1.validatePasswordComplexity(passwordBytes -> 0);
+            fail();
+        } catch (IllegalStateException exception) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testPasswordEqual()
+    {
+        Password p1 = new Password("fixed");
+        Password p2 = new Password(new byte[] { 'f', 'i', 'x', 'e', 'd' });
+        Password p3 = new Password();
+        p3.addCharacter('f');
+        p3.addCharacter('i');
+        p3.addCharacter('x');
+        p3.addCharacter('e');
+        p3.addCharacter('d');
+
+        assertEquals(p1, p1);
+        assertEquals(p2, p2);
+        assertEquals(p3, p3);
+        assertEquals(p1, p2);
+        assertEquals(p1, p3);
+        assertEquals(p2, p3);
+    }
+
+    @Test
+    public void testPasswordNotEqual()
+    {
+        Password p1 = new Password("fixed");
+        Password p2 = new Password("strin");
+        Password p3 = new Password("string");
+        Password p4 = new Password("stri");
+        Password p5 = new Password();
+
+        assertFalse(p1.isEqualToPassword(p2));
+        assertFalse(p1.isEqualToPassword(p3));
+        assertFalse(p1.isEqualToPassword(p4));
+        assertFalse(p1.isEqualToPassword(p5));
+        assertFalse(p2.isEqualToPassword(p3));
+        assertFalse(p2.isEqualToPassword(p4));
+        assertFalse(p2.isEqualToPassword(p5));
+        assertFalse(p3.isEqualToPassword(p4));
+        assertFalse(p3.isEqualToPassword(p5));
+        assertFalse(p4.isEqualToPassword(p5));
+
+        assertNotEquals("fixed", p1);
+        assertNotEquals(p1, "fixed");
+    }
+
+    private String extractStringFromPassword(Password password) {
+        final String[] result = new String[1];
+        password.validatePasswordComplexity(passwordBytes -> {
+            result[0] = new String(passwordBytes, Charset.defaultCharset());
+            return 0;
+        });
+        return result[0];
+    }
+
+    private byte[] extractBytesFromPassword(Password password) {
+        final byte[][] result = new byte[1][1];
+        password.validatePasswordComplexity(passwordBytes -> {
+            result[0] = Arrays.copyOf(passwordBytes, passwordBytes.length);
+            return 0;
+        });
+        return result[0];
+    }
+}

--- a/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		BF86E6E326395F2C004C8AE5 /* PowerAuthCorePublicObjectsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = BF86E6B526395D44004C8AE5 /* PowerAuthCorePublicObjectsTests.mm */; };
 		BF86E75A26395FF4004C8AE5 /* libPowerAuthCoreLibTests-tvos.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6ADDAE24C84FE0001B3E5E /* libPowerAuthCoreLibTests-tvos.a */; };
 		BF86E75B26395FF9004C8AE5 /* PowerAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6ADD6024C84A3D001B3E5E /* PowerAuthCore.framework */; };
+		BF97A71128A2714F002F3ACE /* PowerAuthCorePasswordTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF97A71028A2714F002F3ACE /* PowerAuthCorePasswordTests.m */; };
+		BF97A71228A2714F002F3ACE /* PowerAuthCorePasswordTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF97A71028A2714F002F3ACE /* PowerAuthCorePasswordTests.m */; };
 		BF99D9002073E14100735ED2 /* Session.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8F12073E00D00735ED2 /* Session.cpp */; };
 		BF99D9012073E14100735ED2 /* PublicTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8F22073E00D00735ED2 /* PublicTypes.cpp */; };
 		BF99D9022073E14100735ED2 /* Debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF99D8F32073E00D00735ED2 /* Debug.cpp */; };
@@ -376,6 +378,7 @@
 		BF86E6B526395D44004C8AE5 /* PowerAuthCorePublicObjectsTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PowerAuthCorePublicObjectsTests.mm; sourceTree = "<group>"; };
 		BF86E6EC26395F2C004C8AE5 /* PowerAuthCoreTests-tvos.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PowerAuthCoreTests-tvos.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF8BFBD5215A8EB6001D6852 /* signatures-v3.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "signatures-v3.json"; sourceTree = "<group>"; };
+		BF97A71028A2714F002F3ACE /* PowerAuthCorePasswordTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthCorePasswordTests.m; sourceTree = "<group>"; };
 		BF99D8AD2073E00D00735ED2 /* pa2DataWriterReaderTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pa2DataWriterReaderTests.cpp; sourceTree = "<group>"; };
 		BF99D8B02073E00D00735ED2 /* verify-encrypted-server-public-key-signature.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "verify-encrypted-server-public-key-signature.json"; sourceTree = "<group>"; };
 		BF99D8B12073E00D00735ED2 /* compute-master-secret-key.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "compute-master-secret-key.json"; sourceTree = "<group>"; };
@@ -629,6 +632,7 @@
 				BF86E6B426395D44004C8AE5 /* PowerAuthCoreTestsWrapper.mm */,
 				BF86E6B526395D44004C8AE5 /* PowerAuthCorePublicObjectsTests.mm */,
 				BF31606327E88D7300EDA287 /* PowerAuthCoreCryptoUtilsTests.mm */,
+				BF97A71028A2714F002F3ACE /* PowerAuthCorePasswordTests.m */,
 				BF86E67626395B78004C8AE5 /* Info.plist */,
 			);
 			path = PowerAuthCoreTests;
@@ -1338,6 +1342,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF86E6B626395D44004C8AE5 /* PowerAuthCoreTestsWrapper.mm in Sources */,
+				BF97A71128A2714F002F3ACE /* PowerAuthCorePasswordTests.m in Sources */,
 				BF31606427E88D7300EDA287 /* PowerAuthCoreCryptoUtilsTests.mm in Sources */,
 				BF86E6B726395D44004C8AE5 /* PowerAuthCorePublicObjectsTests.mm in Sources */,
 			);
@@ -1348,6 +1353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF86E6E226395F2C004C8AE5 /* PowerAuthCoreTestsWrapper.mm in Sources */,
+				BF97A71228A2714F002F3ACE /* PowerAuthCorePasswordTests.m in Sources */,
 				BF31606527E88D7300EDA287 /* PowerAuthCoreCryptoUtilsTests.mm in Sources */,
 				BF86E6E326395F2C004C8AE5 /* PowerAuthCorePublicObjectsTests.mm in Sources */,
 			);

--- a/proj-xcode/PowerAuthCore/PowerAuthCorePassword.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCorePassword.h
@@ -98,11 +98,13 @@
 /**
  The method validates stored passphrase with using provided validation block. The raw bytes of 
  the passphrase are revealed to the block, which can decide whether the passphrase's complexity 
- is sufficient or not.
+ is sufficient or not. It's not recommended to copy the plaintext password to another memory
+ location, to minimize traces of the password in the memory.
  
- Returns NO if passphrase is empty, or result returned from the block.
+ Returns value provided by the validation block. The meaning of returned integer depends on
+ validation block's implementation.
  */
-- (BOOL) validatePasswordComplexity:(BOOL (NS_NOESCAPE ^_Nullable)(const UInt8 * _Nonnull  passphrase, NSUInteger length))validationBlock;
+- (NSInteger) validatePasswordComplexity:(NSInteger (NS_NOESCAPE ^_Nonnull)(const UInt8 * _Nonnull  passphrase, NSUInteger length))validationBlock;
 
 @end
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCorePassword.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCorePassword.mm
@@ -59,14 +59,21 @@
     return _password.isEqualToPassword(password->_password);
 }
 
-- (BOOL) validatePasswordComplexity:(BOOL (NS_NOESCAPE ^)(const UInt8* passphrase, NSUInteger length))validationBlock
+- (BOOL) isEqual:(id)object
 {
-    BOOL result = NO;
-    const cc7::byte * plaintext_bytes = _password.passwordData().data();
-    if (validationBlock && plaintext_bytes) {
-        result = validationBlock(plaintext_bytes, _password.passwordData().size());
+    if (object == self) {
+        return YES;
     }
-    return result;
+    if ([object isKindOfClass:[PowerAuthCorePassword class]]) {
+        return [self isEqualToPassword:object];
+    }
+    return NO;
+}
+
+- (NSInteger) validatePasswordComplexity:(NSInteger (NS_NOESCAPE ^)(const UInt8* passphrase, NSUInteger length))validationBlock
+{
+    auto plaintext = _password.passwordData();
+    return validationBlock(plaintext.data(), plaintext.size());
 }
 
 @end

--- a/proj-xcode/PowerAuthCoreTests/PowerAuthCorePasswordTests.m
+++ b/proj-xcode/PowerAuthCoreTests/PowerAuthCorePasswordTests.m
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <XCTest/XCTest.h>
+
+@import PowerAuthCore;
+
+@interface PowerAuthCorePasswordTests : XCTestCase
+@end
+
+@implementation PowerAuthCorePasswordTests
+
+#define DATA_BYTES(vn, ...) \
+    const UInt8 vn##bytes[] = __VA_ARGS__; \
+    NSData * vn = [NSData dataWithBytes:vn##bytes length:sizeof(vn##bytes)];
+
+- (void) testImmutable
+{
+    PowerAuthCorePassword * p1 = [PowerAuthCorePassword passwordWithString:@"HelloWorld"];
+    XCTAssertEqual(10, p1.length);
+    XCTAssertEqualObjects(@"HelloWorld", [self extractStringFromPassword:p1]);
+    
+    PowerAuthCorePassword * p2 = [PowerAuthCorePassword passwordWithString:@"HelloWorld"];
+    XCTAssertTrue([p1 isEqualToPassword:p2]);
+    XCTAssertEqualObjects(p1, p2);
+    
+    DATA_BYTES(p3data, { 1, 2, 3, 4, 5, 6, 7 });
+    PowerAuthCorePassword * p3 = [PowerAuthCorePassword passwordWithData:p3data];
+    XCTAssertEqual(7, p3.length);
+    XCTAssertEqualObjects([p3data copy], [self extractBytesFromPassword:p3]);
+}
+
+- (void) testMutableNumbers
+{
+    PowerAuthCoreMutablePassword * p1 = [PowerAuthCoreMutablePassword mutablePassword];
+    XCTAssertEqual(0, p1.length);
+    
+    XCTAssertTrue([p1 addCharacter:1]);
+    XCTAssertTrue([p1 insertCharacter:3 atIndex:1]);
+    XCTAssertTrue([p1 insertCharacter:0 atIndex:0]);
+    XCTAssertTrue([p1 insertCharacter:2 atIndex:2]);
+    XCTAssertTrue([p1 addCharacter:4]);
+    XCTAssertEqual(5, p1.length);
+    
+    DATA_BYTES(expectedBytes1, { 0, 1, 2, 3, 4});
+    XCTAssertEqualObjects([PowerAuthCorePassword passwordWithData:expectedBytes1], p1);
+    
+    XCTAssertTrue([p1 removeCharacterAtIndex:0]);
+    DATA_BYTES(expectedBytes2, { 1, 2, 3, 4});
+    XCTAssertEqualObjects([PowerAuthCorePassword passwordWithData:expectedBytes2], p1);
+    
+    XCTAssertTrue([p1 removeCharacterAtIndex:1]);
+    DATA_BYTES(expectedBytes3, { 1, 3, 4});
+    XCTAssertEqualObjects([PowerAuthCorePassword passwordWithData:expectedBytes3], p1);
+    
+    XCTAssertTrue([p1 removeCharacterAtIndex:2]);
+    DATA_BYTES(expectedBytes4, { 1, 3 });
+    XCTAssertEqualObjects([PowerAuthCorePassword passwordWithData:expectedBytes4], p1);
+    
+    XCTAssertTrue([p1 removeLastCharacter]);
+    XCTAssertTrue([p1 removeLastCharacter]);
+    
+    // Out of range access
+    XCTAssertFalse([p1 removeLastCharacter]);
+    XCTAssertFalse([p1 removeCharacterAtIndex:0]);
+    XCTAssertFalse([p1 removeCharacterAtIndex:1]);
+    XCTAssertFalse([p1 insertCharacter:11 atIndex:1]);
+    
+    XCTAssertEqual(0, p1.length);
+    XCTAssertTrue([p1 addCharacter:5]);
+    XCTAssertEqual(1, p1.length);
+    
+    [p1 clear];
+    XCTAssertEqual(0, p1.length);
+}
+
+- (void) testMutableUnicode
+{
+    PowerAuthCoreMutablePassword * p1 = [PowerAuthCoreMutablePassword mutablePassword];
+    XCTAssertEqual(0, p1.length);
+    
+    XCTAssertTrue([p1 addCharacter:'e']);
+    XCTAssertTrue([p1 addCharacter:'l']);
+    XCTAssertTrue([p1 insertCharacter:'l' atIndex:1]);
+    XCTAssertTrue([p1 insertCharacter:'o' atIndex:3]);
+    XCTAssertTrue([p1 addCharacter:'W']);
+    XCTAssertTrue([p1 addCharacter:'0']);
+    XCTAssertTrue([p1 addCharacter:'r']);
+    XCTAssertTrue([p1 addCharacter:'l']);
+    XCTAssertTrue([p1 addCharacter:'d']);
+    XCTAssertTrue([p1 insertCharacter:0x397 atIndex:0]);
+    
+    XCTAssertEqual(10, p1.length);
+    XCTAssertEqual(11, [self extractBytesFromPassword:p1].length);
+    XCTAssertEqualObjects(@"ΗelloW0rld", [self extractStringFromPassword:p1]);
+    
+    XCTAssertTrue([p1 removeCharacterAtIndex:0]);
+    XCTAssertEqualObjects(@"elloW0rld", [self extractStringFromPassword:p1]);
+    XCTAssertTrue([p1 removeLastCharacter]);
+    XCTAssertEqualObjects(@"elloW0rl", [self extractStringFromPassword:p1]);
+    XCTAssertTrue([p1 insertCharacter:0x206 atIndex:1]);
+    XCTAssertEqualObjects(@"eȆlloW0rl", [self extractStringFromPassword:p1]);
+    XCTAssertEqual(9, p1.length);
+    XCTAssertTrue([p1 removeCharacterAtIndex:5]);
+    XCTAssertEqualObjects(@"eȆllo0rl", [self extractStringFromPassword:p1]);
+    XCTAssertTrue([p1 removeCharacterAtIndex:1]);
+    XCTAssertEqualObjects(@"ello0rl", [self extractStringFromPassword:p1]);
+}
+
+- (void) testPasswordEqual
+{
+    DATA_BYTES(p2data, { 'f', 'i', 'x', 'e', 'd' });
+    PowerAuthCorePassword * p1 = [PowerAuthCorePassword passwordWithString:@"fixed"];
+    PowerAuthCorePassword * p2 = [PowerAuthCorePassword passwordWithData:p2data];
+    PowerAuthCoreMutablePassword * p3 = [PowerAuthCoreMutablePassword mutablePassword];
+    [p3 addCharacter:'f'];
+    [p3 addCharacter:'i'];
+    [p3 addCharacter:'x'];
+    [p3 addCharacter:'e'];
+    [p3 addCharacter:'d'];
+    XCTAssertEqualObjects(p1, p1);
+    XCTAssertEqualObjects(p2, p2);
+    XCTAssertEqualObjects(p3, p3);
+    XCTAssertEqualObjects(p1, p2);
+    XCTAssertEqualObjects(p1, p3);
+    XCTAssertEqualObjects(p2, p3);
+}
+
+- (void) testPasswordNotEqual
+{
+    PowerAuthCorePassword * p1 = [PowerAuthCorePassword passwordWithString:@"fixed"];
+    PowerAuthCorePassword * p2 = [PowerAuthCorePassword passwordWithString:@"strin"];
+    PowerAuthCorePassword * p3 = [PowerAuthCorePassword passwordWithString:@"string"];
+    PowerAuthCorePassword * p4 = [PowerAuthCorePassword passwordWithString:@"stri"];
+    PowerAuthCorePassword * p5 = [PowerAuthCoreMutablePassword mutablePassword];
+    XCTAssertFalse([p1 isEqualToPassword:p2]);
+    XCTAssertFalse([p1 isEqualToPassword:p3]);
+    XCTAssertFalse([p1 isEqualToPassword:p4]);
+    XCTAssertFalse([p1 isEqualToPassword:p5]);
+    XCTAssertFalse([p2 isEqualToPassword:p3]);
+    XCTAssertFalse([p2 isEqualToPassword:p4]);
+    XCTAssertFalse([p2 isEqualToPassword:p5]);
+    XCTAssertFalse([p3 isEqualToPassword:p4]);
+    XCTAssertFalse([p3 isEqualToPassword:p5]);
+    XCTAssertFalse([p4 isEqualToPassword:p5]);
+    XCTAssertNotEqualObjects(@"fixed", p1);
+    XCTAssertNotEqualObjects(p1, @"fixed");
+}
+
+- (NSString*) extractStringFromPassword:(PowerAuthCorePassword*)password
+{
+    __block NSString * stringPassword = nil;
+    [password validatePasswordComplexity:^NSInteger(const UInt8 * _Nonnull passphrase, NSUInteger length) {
+        stringPassword = [[NSString alloc] initWithBytes:passphrase length:length encoding:NSUTF8StringEncoding];
+        return 0;
+    }];
+    return stringPassword;
+}
+
+- (NSData*) extractBytesFromPassword:(PowerAuthCorePassword*)password
+{
+    __block NSData * passwordData = nil;
+    [password validatePasswordComplexity:^NSInteger(const UInt8 * _Nonnull passphrase, NSUInteger length) {
+        passwordData = [NSData dataWithBytes:passphrase length:length];
+        return 0;
+    }];
+    return passwordData;
+}
+
+@end

--- a/src/PowerAuth/jni/PasswordJNI.cpp
+++ b/src/PowerAuth/jni/PasswordJNI.cpp
@@ -178,4 +178,13 @@ CC7_JNI_METHOD_PARAMS(jboolean, removeCharacter, jint index)
     return pass ? pass->removeCharacter((size_t)index) : false;
 }
 
+//
+// private native byte[] getPlaintextPassword();
+//
+CC7_JNI_METHOD(jbyteArray , getPlaintextPassword)
+{
+	auto pass = CC7_THIS_OBJ();
+	return pass ? cc7::jni::CopyToJavaByteArray(env, pass->passwordData()) : nullptr;
+}
+
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthTests/pa2PasswordTests.cpp
+++ b/src/PowerAuthTests/pa2PasswordTests.cpp
@@ -90,9 +90,9 @@ namespace powerAuthTests
             ccstAssertTrue(result);
             result = p1.addCharacter(1);
             ccstAssertTrue(result);
-            result = p1.addCharacter(2);
+            result = p1.insertCharacter(3, 2);
             ccstAssertTrue(result);
-            result = p1.addCharacter(3);
+            result = p1.insertCharacter(2, 2);
             ccstAssertTrue(result);
             ccstAssertEqual(p1.length(), 4);
             ccstAssertEqual(p1.passwordData(), cc7::ByteArray({0, 1, 2, 3}));
@@ -115,6 +115,7 @@ namespace powerAuthTests
             ccstAssertFalse(result);
             result = p1.insertCharacter(11, 1);
             ccstAssertFalse(result);
+            ccstAssertEqual(0, p1.length());
         }
 
         void testMutableUnicode()


### PR DESCRIPTION
This PR adds simple passphrase obfuscation to our "core" password objects . The method of obfuscation is based on a simple XOR function, with using random 16 bytes as cyclic key.

The change also contains the following modifications:

- Added high level tests for `Password` (android) & `PowerAuthCorePassword` (ios, tvos)
- Removed CC7_CHECK from `Password.cpp` implementation. This has no effect on functionality, but it required due to problematic unit testing on iOS. 
- Added `Password.validatePasswordComplexity` function to Android impl.
- Changed `PowerAuthCorePassword.validatePasswordComplexity()` return value.