### PR TITLE
LAContext improvements

### DIFF
--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1063,7 +1063,17 @@ PowerAuthSDK.sharedInstance().authenticateUsingBiometry(withContext: laContext) 
 The usage of `LAContext` has the following limitations:
 
 - It's effective from iOS 11 because on the older operating systems the context doesn't support essential properties, such as `localizedReason`.
-- Don't alter `interactionNotAllowed` property. If you do, then the internal SDK implementation rejects the context and reports user cancel error.
+- Don't alter `interactionNotAllowed` property. If you do, then the internal SDK implementation rejects the context and the biometry cancel is reported.
+
+Be aware that PowerAuth automatically invalidates the application provided `LAContext` after use. This is because once the context is successfully evaluated then it can be used for a quite long time to fetch the data protected with the biometry with no prompt displayed. The exact time of validity is undocumented, but our experiments show that iOS prompts for biometric authentication after more than 5 minutes.
+
+If you plan to pre-authorize `LAContext` and use it for multiple biometry signature calculations in a row, then please consider the following things first:
+
+- Make sure that you make context invalid once it's no longer needed.
+- Multiple signatures in a row could be problematic from the PSD2 legislative perspective. 
+- It would be difficult to prove that the user authorized the request if your application contains a bug and do the signature on the user's behalf or with the wrong context.
+
+If you still insist to re-use `LAContext` then you have to alter `PowerAuthKeychainConfiguration` and set `invalidateLocalAuthenticationContextAfterUse` to `false`.
 
 
 ## Activation Removal

--- a/proj-xcode/PowerAuth2/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychain.m
@@ -130,10 +130,7 @@
     
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }
@@ -153,7 +150,7 @@
 }
 
 
-static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth)
+static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth, OSStatus * status)
 {
     NSString * prompt = auth.prompt;
 #if PA2_HAS_LACONTEXT == 1
@@ -162,6 +159,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
         if (@available(iOS 11, macCatalyst 10.15, *)) {
             if (context.interactionNotAllowed) {
                 PowerAuthLog(@"LAContext.interactionNotAllowed should not be set to true");
+                if (status) { *status = errSecInvalidContext; }
                 return NO;
             }
         }
@@ -180,6 +178,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
 #endif // PA2_HAS_LACONTEXT
     if (!prompt) {
         PowerAuthLog(@"PowerAuthKeychainAuthentication has no prompt or LAContext set.");
+        if (status) { *status = errSecInvalidContext; }
         return NO;
     }
     query[(__bridge id)kSecUseOperationPrompt] = prompt;
@@ -231,10 +230,7 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }

--- a/proj-xcode/PowerAuth2/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychain.m
@@ -405,7 +405,7 @@ static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeych
     
     // Try to acquire biometric lock.
     if (pthread_mutex_trylock(&biometricMutex) != 0) {
-        PowerAuthLog(@"Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
+        PowerAuthLog(@"WARNING: Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
         return NO;
     }
     // Execute block

--- a/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.h
@@ -108,6 +108,12 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
 
+/**
+ If set to YES, then the LAContext object provided by application is invalidated after the use in SDK.
+ The default value is YES, so `LAContext` cannot be reused for getting keys protected with biometry.
+ */
+@property (nonatomic, assign) BOOL invalidateLocalAuthenticationContextAfterUse;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2/PowerAuthKeychainConfiguration.m
@@ -44,6 +44,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         // Default config for biometry protected items
         _linkBiometricItemsToCurrentSet = NO;
         _allowBiometricAuthenticationFallbackToDevicePasscode = NO;
+        _invalidateLocalAuthenticationContextAfterUse = YES;
     }
     return self;
 }
@@ -61,6 +62,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         c->_keychainKey_Possession = _keychainKey_Possession;
         c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
         c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
+        c->_invalidateLocalAuthenticationContextAfterUse = _invalidateLocalAuthenticationContextAfterUse;
     }
     return c;
 }

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -516,7 +516,8 @@
  @param callback A callback with result, always executed on the main thread.
  */
 - (void) authenticateUsingBiometryWithPrompt:(nonnull NSString *)prompt
-                                    callback:(nonnull void(^)(PowerAuthAuthentication * _Nullable authentication, NSError * _Nullable error))callback;
+                                    callback:(nonnull void(^)(PowerAuthAuthentication * _Nullable authentication, NSError * _Nullable error))callback
+                                NS_SWIFT_NAME(authenticateUsingBiometry(withPrompt:callback:));
 
 /** Prepare PowerAuthAuthentication object for future PowerAuth signature calculation with a biometry and possession factors involved.
  
@@ -528,21 +529,26 @@
  @param callback A callback with result, always executed on the main thread.
  */
 - (void) authenticateUsingBiometryWithContext:(nonnull LAContext *)context
-                                     callback:(nonnull void(^)(PowerAuthAuthentication * _Nullable authentication, NSError * _Nullable error))callback API_UNAVAILABLE(tvos);
+                                     callback:(nonnull void(^)(PowerAuthAuthentication * _Nullable authentication, NSError * _Nullable error))callback
+                                NS_SWIFT_NAME(authenticateUsingBiometry(withContext:callback:))
+                                API_UNAVAILABLE(tvos);
 
 /** Unlock all keys stored in a biometry related keychain and keeps them cached for the scope of the block.
  
  There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
  */
 - (void) unlockBiometryKeysWithPrompt:(nonnull NSString*)prompt
-                            withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block;
+                            withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block
+                         NS_SWIFT_NAME(unlockBiometryKeys(withPrompt:callback:));
 
 /** Unlock all keys stored in a biometry related keychain and keeps them cached for the scope of the block.
  
  There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
  */
 - (void) unlockBiometryKeysWithContext:(nonnull LAContext*)context
-                             withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block API_UNAVAILABLE(tvos);
+                             withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block
+                          NS_SWIFT_NAME(unlockBiometryKeys(withContext:callback:))
+                          API_UNAVAILABLE(tvos);
 
 /** Generate an derived encryption key with given index.
  

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
@@ -130,10 +130,7 @@
     
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }
@@ -153,7 +150,7 @@
 }
 
 
-static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth)
+static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth, OSStatus * status)
 {
     NSString * prompt = auth.prompt;
 #if PA2_HAS_LACONTEXT == 1
@@ -162,6 +159,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
         if (@available(iOS 11, macCatalyst 10.15, *)) {
             if (context.interactionNotAllowed) {
                 PowerAuthLog(@"LAContext.interactionNotAllowed should not be set to true");
+                if (status) { *status = errSecInvalidContext; }
                 return NO;
             }
         }
@@ -180,6 +178,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
 #endif // PA2_HAS_LACONTEXT
     if (!prompt) {
         PowerAuthLog(@"PowerAuthKeychainAuthentication has no prompt or LAContext set.");
+        if (status) { *status = errSecInvalidContext; }
         return NO;
     }
     query[(__bridge id)kSecUseOperationPrompt] = prompt;
@@ -231,10 +230,7 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychain.m
@@ -405,7 +405,7 @@ static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeych
     
     // Try to acquire biometric lock.
     if (pthread_mutex_trylock(&biometricMutex) != 0) {
-        PowerAuthLog(@"Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
+        PowerAuthLog(@"WARNING: Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
         return NO;
     }
     // Execute block

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.h
@@ -108,6 +108,12 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
 
+/**
+ If set to YES, then the LAContext object provided by application is invalidated after the use in SDK.
+ The default value is YES, so `LAContext` cannot be reused for getting keys protected with biometry.
+ */
+@property (nonatomic, assign) BOOL invalidateLocalAuthenticationContextAfterUse;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2ForExtensions/PowerAuthKeychainConfiguration.m
@@ -44,6 +44,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         // Default config for biometry protected items
         _linkBiometricItemsToCurrentSet = NO;
         _allowBiometricAuthenticationFallbackToDevicePasscode = NO;
+        _invalidateLocalAuthenticationContextAfterUse = YES;
     }
     return self;
 }
@@ -61,6 +62,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         c->_keychainKey_Possession = _keychainKey_Possession;
         c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
         c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
+        c->_invalidateLocalAuthenticationContextAfterUse = _invalidateLocalAuthenticationContextAfterUse;
     }
     return c;
 }

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
@@ -130,10 +130,7 @@
     
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }
@@ -153,7 +150,7 @@
 }
 
 
-static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth)
+static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKeychainAuthentication * auth, OSStatus * status)
 {
     NSString * prompt = auth.prompt;
 #if PA2_HAS_LACONTEXT == 1
@@ -162,6 +159,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
         if (@available(iOS 11, macCatalyst 10.15, *)) {
             if (context.interactionNotAllowed) {
                 PowerAuthLog(@"LAContext.interactionNotAllowed should not be set to true");
+                if (status) { *status = errSecInvalidContext; }
                 return NO;
             }
         }
@@ -180,6 +178,7 @@ static BOOL _AddKeychainAuthentication(NSMutableDictionary * query, PowerAuthKey
 #endif // PA2_HAS_LACONTEXT
     if (!prompt) {
         PowerAuthLog(@"PowerAuthKeychainAuthentication has no prompt or LAContext set.");
+        if (status) { *status = errSecInvalidContext; }
         return NO;
     }
     query[(__bridge id)kSecUseOperationPrompt] = prompt;
@@ -231,10 +230,7 @@ static void _AddUseNoAuthenticationUI(NSMutableDictionary * query)
 
     // Add authentication for items protected with biometry.
     if (authentication) {
-        if (!_AddKeychainAuthentication(query, authentication)) {
-            if (status) {
-                *status = errSecUserCanceled;
-            }
+        if (!_AddKeychainAuthentication(query, authentication, status)) {
             return nil;
         }
     }

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychain.m
@@ -405,7 +405,7 @@ static SecAccessControlCreateFlags _getBiometryAccessControlFlags(PowerAuthKeych
     
     // Try to acquire biometric lock.
     if (pthread_mutex_trylock(&biometricMutex) != 0) {
-        PowerAuthLog(@"Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
+        PowerAuthLog(@"WARNING: Cannot execute more than one biometric authentication request at the same time. This request is going to be canceled.");
         return NO;
     }
     // Execute block

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.h
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.h
@@ -108,6 +108,12 @@ extern NSString * __nonnull const PowerAuthKeychainKey_Possession;
  */
 @property (nonatomic, assign) BOOL allowBiometricAuthenticationFallbackToDevicePasscode;
 
+/**
+ If set to YES, then the LAContext object provided by application is invalidated after the use in SDK.
+ The default value is YES, so `LAContext` cannot be reused for getting keys protected with biometry.
+ */
+@property (nonatomic, assign) BOOL invalidateLocalAuthenticationContextAfterUse;
+
 /** Return the shared in stance of a Keychain configuration object.
  
  @return Shared instance of a Keychain configuration.

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthKeychainConfiguration.m
@@ -44,6 +44,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         // Default config for biometry protected items
         _linkBiometricItemsToCurrentSet = NO;
         _allowBiometricAuthenticationFallbackToDevicePasscode = NO;
+        _invalidateLocalAuthenticationContextAfterUse = YES;
     }
     return self;
 }
@@ -61,6 +62,7 @@ NSString *const PowerAuthKeychainKey_Possession     = PA2Def_PowerAuthKeychainKe
         c->_keychainKey_Possession = _keychainKey_Possession;
         c->_linkBiometricItemsToCurrentSet = _linkBiometricItemsToCurrentSet;
         c->_allowBiometricAuthenticationFallbackToDevicePasscode = _allowBiometricAuthenticationFallbackToDevicePasscode;
+        c->_invalidateLocalAuthenticationContextAfterUse = _invalidateLocalAuthenticationContextAfterUse;
     }
     return c;
 }


### PR DESCRIPTION
This PR adds various improvements to LAContext usage in SDK:

- LAContext is automatically invalidated after use
- Fixed naming of PowerAuthSDK methods using LAContext
- Improved error reporting when SDK fails to fetch biometry key from the keychain
- Added "Biometry troubleshooting" section to documentation, explaining in more detail possible failures with biometry.