### PR TITLE
Android: Reveal activationId & fingerprint in pending activation

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
@@ -45,6 +45,7 @@ import io.getlime.security.powerauth.sdk.PowerAuthSDK;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -267,6 +268,8 @@ public class ActivationHelper {
         assertFalse(powerAuthSDK.hasValidActivation());
         assertFalse(powerAuthSDK.hasPendingActivation());
         assertTrue(powerAuthSDK.canStartActivation());
+        assertNull(powerAuthSDK.getActivationIdentifier());
+        assertNull(powerAuthSDK.getActivationFingerprint());
 
         final List<String> passwords = prepareAuthentications();
 
@@ -298,11 +301,15 @@ public class ActivationHelper {
             assertFalse(powerAuthSDK.hasValidActivation());
             assertTrue(powerAuthSDK.hasPendingActivation());
             assertFalse(powerAuthSDK.canStartActivation());
+            assertNull(powerAuthSDK.getActivationIdentifier());
+            assertNull(powerAuthSDK.getActivationFingerprint());
         });
 
         assertFalse(powerAuthSDK.hasValidActivation());
         assertTrue(powerAuthSDK.hasPendingActivation());
         assertFalse(powerAuthSDK.canStartActivation());
+        assertNotNull(powerAuthSDK.getActivationIdentifier());
+        assertNotNull(powerAuthSDK.getActivationFingerprint());
 
         // Commit activation locally
         int resultCode;
@@ -320,6 +327,8 @@ public class ActivationHelper {
         assertTrue(powerAuthSDK.hasValidActivation());
         assertFalse(powerAuthSDK.hasPendingActivation());
         assertFalse(powerAuthSDK.canStartActivation());
+        assertNotNull(powerAuthSDK.getActivationIdentifier());
+        assertNotNull(powerAuthSDK.getActivationFingerprint());
 
         // Fetch status to test whether it's in "pending commit" or "active" state, depending on server's configuration.
         final boolean isAutoCommit = testHelper.getTestConfig().isServerAutoCommit();

--- a/src/PowerAuth/jni/SessionJNI.cpp
+++ b/src/PowerAuth/jni/SessionJNI.cpp
@@ -228,10 +228,10 @@ CC7_JNI_METHOD(jboolean, hasValidActivation)
 CC7_JNI_METHOD(jstring, getActivationIdentifier)
 {
     auto session = CC7_THIS_OBJ();
-    if (!session || !session->hasValidActivation()) {
+    if (!session) {
         return NULL;
     }
-    return cc7::jni::CopyToJavaString(env, session->activationIdentifier());
+    return cc7::jni::CopyToNullableJavaString(env, session->activationIdentifier());
 }
 
 //
@@ -240,7 +240,7 @@ CC7_JNI_METHOD(jstring, getActivationIdentifier)
 CC7_JNI_METHOD(jstring, getActivationFingerprint)
 {
     auto session = CC7_THIS_OBJ();
-    if (!session || !session->hasValidActivation()) {
+    if (!session) {
         return NULL;
     }
     return cc7::jni::CopyToNullableJavaString(env, session->activationFingerprint());

--- a/src/PowerAuthTests/pa2OtpUtilTests.cpp
+++ b/src/PowerAuthTests/pa2OtpUtilTests.cpp
@@ -86,7 +86,7 @@ namespace powerAuthTests
                 "KLMNO-PQRST-UVWXY-Z234",
                 "KLMNO-PQRST-UVWXY-Z2345 ",
                 "KLMNO-PQRST-UVWXY-Z2345#",
-                "67AAA-B0BCC-DDEEF-GGHHI"
+                "67AAA-B0BCC-DDEEF-GGHHI",
                 "67AAA-BB1CC-DDEEF-GGHHI",
                 "67AAA-BBBC8-DDEEF-GGHHI",
                 "67AAA-BBBCC-DDEEF-GGHH9",
@@ -259,7 +259,7 @@ namespace powerAuthTests
                 "KLMNO-PQRST-UVWXY-Z2345#",
                 "NQHGX-LNM2S-EQ4NT-G3NAA#aGVsbG8td29ybGQ=",
                 "R:NQHGX-LNM2S-EQ4NT-G3NAA#aGVsbG8td29ybGQ=",
-                "67AAA-B0BCC-DDEEF-GGHHI"
+                "67AAA-B0BCC-DDEEF-GGHHI",
                 "67AAA-BB1CC-DDEEF-GGHHI",
                 "67AAA-BBBC8-DDEEF-GGHHI",
                 "67AAA-BBBCC-DDEEF-GGHH9",


### PR DESCRIPTION
This PR fixes an issue when Activation Id and Activation Fingerprint is not available after key-exchange on Android platform. 

On top of that it fixes missing comma in C++ test class. The result of the test is not affected, but test data now contains originally intended test vectors.