### PR TITLE
Fix #490: Allow null in Session.prepareKeyValueDictionaryForDataSigning()

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
@@ -269,6 +269,9 @@ public class Session {
      * @return normalized byte array, prepared for data signing
      */
     public byte[] prepareKeyValueDictionaryForDataSigning(Map<String, String> keyValueMap) {
+        if (keyValueMap == null) {
+            return null;
+        }
         ArrayList<String> keys = new ArrayList<>();
         ArrayList<String> values = new ArrayList<>();
         for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {


### PR DESCRIPTION
Fixes crash when null is provided to `Session.prepareKeyValueDictionaryForDataSigning()`