### PR TITLE
Apple: Fix #492: Targeting code to iOS 11+

### DIFF
--- a/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
@@ -53,20 +53,16 @@
 
 - (BOOL) sendActivationStatusToWatch
 {
-    if (@available(iOS 9, *)) {
-        PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
-        if (manager.validSession == nil) {
-            return NO;
-        }
-        PA2WCSessionPacket * packet = [self prepareActivationStatusPacket];
-        if (!packet) {
-            return NO;
-        }
-        [manager sendPacket:packet];
-        return YES;
+    PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
+    if (manager.validSession == nil) {
+        return NO;
     }
-    PowerAuthLog(@"PowerAuthSDK: Not supported on older iOS versions.");
-    return NO;
+    PA2WCSessionPacket * packet = [self prepareActivationStatusPacket];
+    if (!packet) {
+        return NO;
+    }
+    [manager sendPacket:packet];
+    return YES;
 }
 
 

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -354,6 +354,11 @@ NSString *const PowerAuthExceptionMissingConfig = @"PowerAuthExceptionMissingCon
                     // Be aware that this code is generated in our keychain impl. Don't be confused with the naming,
                     // if LAContext is already invalidated, then general `errSecAuthFailed` is returned.
                     localError = PA2MakeError(PowerAuthErrorCode_BiometryFailed, @"Invalid LAContext");
+                } else if (status == errSecUnimplemented) {
+                    // PowerAuthKeychainAuthentication was provided on platform that doesn't support it.
+                    // This may happen only if tvOS application proactively create biometric key in the biometry keychain.
+                    // In regular and expected setup, accessing biometry protected item on tvOS fails with errSecItemNotFound.
+                    localError = PA2MakeError(PowerAuthErrorCode_BiometryFailed, @"PowerAuthKeychainAuthentication not supported");
                 } else {
                     localError = nil;
                 }

--- a/proj-xcode/PowerAuth2/PowerAuthToken+WatchSupport.m
+++ b/proj-xcode/PowerAuth2/PowerAuthToken+WatchSupport.m
@@ -48,19 +48,15 @@
 
 - (BOOL) sendToWatch
 {
-    if (@available(iOS 9, *)) {
-        if ([self.tokenStore canRequestForAccessToken]) {
-            PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
-            if (manager.validSession) {
-                [manager sendPacket:[self prepareTokenDataPacketForWatch]];
-                return YES;
-            }
-            PowerAuthLog(@"PowerAuthToken: WCSession is not ready for message sending.");
-        } else {
-            PowerAuthLog(@"PowerAuthToken: Cannot send token to watch, because token store has no longer a valid activation.");
+    if ([self.tokenStore canRequestForAccessToken]) {
+        PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
+        if (manager.validSession) {
+            [manager sendPacket:[self prepareTokenDataPacketForWatch]];
+            return YES;
         }
+        PowerAuthLog(@"PowerAuthToken: WCSession is not ready for message sending.");
     } else {
-        PowerAuthLog(@"PowerAuthToken: WCSession is not supported on older iOS versions.");
+        PowerAuthLog(@"PowerAuthToken: Cannot send token to watch, because token store has no longer a valid activation.");
     }
     return NO;
 }
@@ -103,12 +99,10 @@
 
 - (BOOL) removeFromWatch
 {
-    if (@available(iOS 9, *)) {
-        PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
-        if (manager.validSession) {
-            [manager sendPacket:[self prepareTokenRemovePacketForWatch]];
-            return YES;
-        }
+    PowerAuthWCSessionManager * manager = [PowerAuthWCSessionManager sharedInstance];
+    if (manager.validSession) {
+        [manager sendPacket:[self prepareTokenRemovePacketForWatch]];
+        return YES;
     }
     PowerAuthLog(@"PowerAuthToken: WCSession is not ready for message sending.");
     return NO;
@@ -117,20 +111,14 @@
 
 - (void) removeFromWatchWithCompletion:(void(^ _Nonnull)(NSError * _Nullable error))completion
 {
-    if (@available(iOS 9, *)) {
-        PA2WCSessionPacket * packet = [self prepareTokenRemovePacketForWatch];
-        [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_Success class] completion:^(PA2WCSessionPacket *response, NSError *error) {
-            if (completion) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    completion(error);
-                });
-            }
-        }];
-    } else {
+    PA2WCSessionPacket * packet = [self prepareTokenRemovePacketForWatch];
+    [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_Success class] completion:^(PA2WCSessionPacket *response, NSError *error) {
         if (completion) {
-            completion(PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"Not supported on older iOS versions"));
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(error);
+            });
         }
-    }
+    }];
 }
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
@@ -444,15 +444,11 @@ static WCSession * _PrepareSession()
 
 static WCSession * _ValidateSession(WCSession * session)
 {
-    if (@available(watchOS 2.2, *)) {
-        if (session.activationState == WCSessionActivationStateActivated) {
-            return session;
-        } else {
-            PowerAuthLog(@"PA2WCSessionManager: WCSession is not activated on this device.");
-            return nil;
-        }
+    if (session.activationState == WCSessionActivationStateActivated) {
+        return session;
     }
-    return session;
+    PowerAuthLog(@"PA2WCSessionManager: WCSession is not activated on this device.");
+    return nil;
 }
 
 #endif // defined(PA2_WATCH_SDK)
@@ -466,11 +462,8 @@ static WCSession * _ValidateSession(WCSession * session)
 
 static WCSession * _PrepareSession()
 {
-    // On IOS, check if session is supported
-    if (@available(iOS 9.0, *)) {
-        if ([WCSession isSupported]) {
-            return [WCSession defaultSession];
-        }
+    if ([WCSession isSupported]) {
+        return [WCSession defaultSession];
     }
     return nil;
 }
@@ -479,11 +472,7 @@ static WCSession * _ValidateSession(WCSession * session)
 {
     // Check if session is paired and watch App is installed
     if (session.isPaired && session.isWatchAppInstalled) {
-        if (@available(iOS 9.3, *)) {
-            if (session.activationState == WCSessionActivationStateActivated) {
-                return session;
-            }
-        } else {
+        if (session.activationState == WCSessionActivationStateActivated) {
             return session;
         }
     }

--- a/proj-xcode/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -444,15 +444,11 @@ static WCSession * _PrepareSession()
 
 static WCSession * _ValidateSession(WCSession * session)
 {
-    if (@available(watchOS 2.2, *)) {
-        if (session.activationState == WCSessionActivationStateActivated) {
-            return session;
-        } else {
-            PowerAuthLog(@"PA2WCSessionManager: WCSession is not activated on this device.");
-            return nil;
-        }
+    if (session.activationState == WCSessionActivationStateActivated) {
+        return session;
     }
-    return session;
+    PowerAuthLog(@"PA2WCSessionManager: WCSession is not activated on this device.");
+    return nil;
 }
 
 #endif // defined(PA2_WATCH_SDK)
@@ -466,11 +462,8 @@ static WCSession * _ValidateSession(WCSession * session)
 
 static WCSession * _PrepareSession()
 {
-    // On IOS, check if session is supported
-    if (@available(iOS 9.0, *)) {
-        if ([WCSession isSupported]) {
-            return [WCSession defaultSession];
-        }
+    if ([WCSession isSupported]) {
+        return [WCSession defaultSession];
     }
     return nil;
 }
@@ -479,11 +472,7 @@ static WCSession * _ValidateSession(WCSession * session)
 {
     // Check if session is paired and watch App is installed
     if (session.isPaired && session.isWatchAppInstalled) {
-        if (@available(iOS 9.3, *)) {
-            if (session.activationState == WCSessionActivationStateActivated) {
-                return session;
-            }
-        } else {
+        if (session.activationState == WCSessionActivationStateActivated) {
             return session;
         }
     }

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
@@ -1127,9 +1127,18 @@
         return;
     }
     
-    PowerAuthAuthentication * authentication = [PowerAuthAuthentication possessionWithBiometry];
+    PowerAuthAuthentication * authentication;
+    PowerAuthAuthorizationHttpHeader * header;
+    
     NSError * error = nil;
-    PowerAuthAuthorizationHttpHeader * header = [_sdk requestSignatureWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
+    authentication = [PowerAuthAuthentication possessionWithBiometry];
+    header = [_sdk requestSignatureWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
+    XCTAssertNil(header);
+    XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
+    
+    error = nil;
+    authentication = [PowerAuthAuthentication possessionWithBiometryPrompt:@"Authenticate with biometry"];
+    header = [_sdk requestSignatureWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
     XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
 }
@@ -1205,12 +1214,7 @@
     
     // Use context with `interactionNotAllowed`
     LAContext * context = [[LAContext alloc] init];
-    if (@available(iOS 11, macCatalyst 10.15, *)) {
-        context.interactionNotAllowed = YES;
-    } else {
-        XCTFail(@"This test require iOS11+");
-        return;
-    }
+    context.interactionNotAllowed = YES;
     
     PowerAuthSdkActivation * activation = [_helper createActivationWithFlags:TestActivationFlags_CommitWithBiometry activationOtp:nil];
     if (!activation) {


### PR DESCRIPTION
This PR cleanups iOS, tvOS & watchOS codebase from the already ineffective platform checks. 

Just for note, currently we support iOS 11+, tvOS 11+ and watchOS 4+