### PR TITLE
Copy Core Password

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/core/PasswordTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/core/PasswordTest.java
@@ -187,6 +187,38 @@ public class PasswordTest {
         assertNotEquals(p1, "fixed");
     }
 
+    @Test
+    public void testPasswordCopy() {
+        Password p1 = new Password("fixed");
+        Password p2 = new Password(new byte[] { 'f', 'i', 'x', 'e', 'd' });
+        Password p3 = new Password();
+        Password p4 = new Password("tested");
+        p3.addCharacter('f');
+        p3.addCharacter('i');
+        p3.addCharacter('x');
+        p3.addCharacter('e');
+        p3.addCharacter('d');
+        p4.destroy();
+
+        assertEquals(p1, p1);
+        assertEquals(p2, p2);
+        assertEquals(p3, p3);
+        assertEquals(p1, p2);
+        assertEquals(p1, p3);
+        assertEquals(p2, p3);
+
+        // Now make copy
+        Password p1copy = p1.copyToImmutable();
+        Password p2copy = p2.copyToImmutable();
+        Password p3copy = p3.copyToImmutable();
+        Password p4copy = p4.copyToImmutable();
+        assertEquals(p1, p1copy);
+        assertEquals(p2, p2copy);
+        assertEquals(p3, p3copy);
+        assertEquals(0, p4.length());
+        assertNotEquals(p4, p4copy); // compare to destroyed is always false
+    }
+
     private String extractStringFromPassword(Password password) {
         final String[] result = new String[1];
         password.validatePasswordComplexity(passwordBytes -> {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Password.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Password.java
@@ -91,7 +91,7 @@ public class Password {
      * @param passphrase string with password.
      */
     public Password(String passphrase) {
-        this.handle = this.initPassword(passphrase, null);
+        this(initPassword(passphrase, null, null));
     }
     
     /**
@@ -102,14 +102,22 @@ public class Password {
      * @param passphrase bytes with password
      */
     public Password(byte[] passphrase) {
-        this.handle = this.initPassword(null, passphrase);
+       this(initPassword(null, passphrase, null));
     }
     
     /**
      * Constructs a new instance of empty, <b>mutable</b> Password object.
      */
     public Password() {
-        this.handle = this.initPassword(null, null);
+        this(initPassword(null, null, null));
+    }
+
+    /**
+     * Construct a password with an already created handle pointing to a native object.
+     * @param handle Handle, or 0, if the object is already destroyed.
+     */
+    private Password(long handle) {
+        this.handle = handle;
     }
     
     /**
@@ -119,8 +127,9 @@ public class Password {
      *
      * @param strPass password in string representation
      * @param dataPass raw password bytes
+     * @param other Other password to copy.
      */
-    private native long initPassword(String strPass, byte[] dataPass);
+    private static native long initPassword(String strPass, byte[] dataPass, Password other);
     
     
     /**
@@ -133,6 +142,16 @@ public class Password {
             destroy(this.handle);
             this.handle = 0;
         }
+    }
+
+    /**
+     * Create an immutable copy from this Password. If the password object is already destroyed,
+     * then the created copy is also marked as a destroyed.
+     * @return Immutable
+     */
+    @NonNull
+    public synchronized Password copyToImmutable() {
+        return new Password(initPassword(null, null, this));
     }
     
     /**

--- a/proj-xcode/PowerAuthCore/PowerAuthCorePassword.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCorePassword.h
@@ -131,6 +131,19 @@
  */
 - (NSInteger) validatePasswordComplexity:(NSInteger (NS_NOESCAPE ^_Nonnull)(const char * _Nonnull  passphrase, NSInteger length))validationBlock;
 
+/**
+ The method wipes out the passphrase stored in the object from the memory. If the object is immutable,
+ then it's no longer usable for the cryptographic operations. If the object is mutable, then
+ the function is equal to `clear()`.
+ */
+- (void) secureClear;
+
+/**
+ The method creates a new `PowerAuthCorePassword` immutable instance that will contain the same passphrase
+ as the receiver.
+ */
+- (nonnull PowerAuthCorePassword*) copyToImmutable;
+
 @end
 
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCorePassword.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCorePassword.mm
@@ -44,6 +44,15 @@
     return self;
 }
 
+- (instancetype) initWithCopy:(nonnull PowerAuthCorePassword*)other
+{
+    self = [super init];
+    if (self) {
+        _password.initAsImmutable(other->_password.passwordData());
+    }
+    return self;
+}
+
 - (instancetype) initMutable
 {
     self = [super init];
@@ -98,6 +107,16 @@
     // the correct size.
     plaintext.append(0);
     return validationBlock((const char*)plaintext.data(), size);
+}
+
+- (void) secureClear
+{
+    _password.secureClear();
+}
+
+- (PowerAuthCorePassword*) copyToImmutable
+{
+    return [[PowerAuthCorePassword alloc] initWithCopy:self];
 }
 
 @end

--- a/proj-xcode/PowerAuthCoreTests/PowerAuthCorePasswordTests.m
+++ b/proj-xcode/PowerAuthCoreTests/PowerAuthCorePasswordTests.m
@@ -160,6 +160,53 @@
     XCTAssertNotEqualObjects(p1, @"fixed");
 }
 
+- (void) testPasswordCopyAndSecureClear
+{
+    // Prepare data
+    DATA_BYTES(p2data, { 'f', 'i', 'x', 'e', 'd' });
+    PowerAuthCorePassword * p1 = [PowerAuthCorePassword passwordWithString:@"fixed"];
+    PowerAuthCorePassword * p2 = [PowerAuthCorePassword passwordWithData:p2data];
+    PowerAuthCoreMutablePassword * p3 = [PowerAuthCoreMutablePassword mutablePassword];
+    [p3 addCharacter:'f'];
+    [p3 addCharacter:'i'];
+    [p3 addCharacter:'x'];
+    [p3 addCharacter:'e'];
+    [p3 addCharacter:'d'];
+    // Now make copy from passwords
+    PowerAuthCorePassword * p1copy = [p1 copyToImmutable];
+    PowerAuthCorePassword * p2copy = [p2 copyToImmutable];
+    PowerAuthCorePassword * p3copy = [p3 copyToImmutable];
+    XCTAssertTrue([p1copy isEqualToPassword:p1]);
+    XCTAssertTrue([p2copy isEqualToPassword:p2]);
+    XCTAssertTrue([p3copy isEqualToPassword:p3]);
+    // Make sure original objects are not modified
+    XCTAssertEqualObjects(@"fixed", [self extractStringFromPassword: p1]);
+    XCTAssertEqualObjects(@"fixed", [self extractStringFromPassword: p2]);
+    XCTAssertEqualObjects(@"fixed", [self extractStringFromPassword: p3]);
+    
+    // Now secure clear all passwords
+    [p1 secureClear];
+    [p2 secureClear];
+    [p3 secureClear];
+    [p1copy secureClear];
+    [p2copy secureClear];
+    [p3copy secureClear];
+    XCTAssertEqual(0, [p1 length]);
+    XCTAssertEqual(0, [p2 length]);
+    XCTAssertEqual(0, [p3 length]);
+    XCTAssertEqual(0, [p1copy length]);
+    XCTAssertEqual(0, [p2copy length]);
+    XCTAssertEqual(0, [p3copy length]);
+    XCTAssertTrue([p1copy isEqualToPassword:p1]);
+    XCTAssertTrue([p2copy isEqualToPassword:p2]);
+    XCTAssertTrue([p3copy isEqualToPassword:p3]);
+    // P3 should still work as mutable
+    [p3 addCharacter:'f'];
+    [p3 addCharacter:'i'];
+    [p3 addCharacter:'x'];
+    XCTAssertEqualObjects(@"fix", [self extractStringFromPassword: p3]);
+}
+
 - (NSString*) extractStringFromPassword:(PowerAuthCorePassword*)password
 {
     __block NSString * stringPassword = nil;


### PR DESCRIPTION
This PR adds methods for copying core passwords into immutable objects. See associated ticket #500 for more details.