### PR TITLE
Issues/507 clear activation status

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
@@ -30,14 +30,16 @@ public enum ServerVersion {
     V1_1_0("1.1", 1001000, ProtocolVersion.V3_1),
     V1_2_0("1.2", 1002000, ProtocolVersion.V3_1),
     V1_2_5("1.2.5", 1002005, ProtocolVersion.V3_1),
-    V1_3_0("1.3", 1003000, ProtocolVersion.V3_1)
+    V1_3_0("1.3", 1003000, ProtocolVersion.V3_1),
+    V1_4_0("1.4", 1004000, ProtocolVersion.V3_1),
+    V1_5_0("1.5", 1005000, ProtocolVersion.V3_1),
 
     ;
 
     /**
      * Contains constant for the latest PowerAuth Server version.
      */
-    public static final ServerVersion LATEST = V1_3_0;
+    public static final ServerVersion LATEST = V1_5_0;
 
     /**
      * Server version represented as string.

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/StandardActivationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/StandardActivationTest.java
@@ -306,6 +306,10 @@ public class StandardActivationTest {
         testHelper.getServerApi().activationRemove(activationHelper.getActivation());
         status = activationHelper.fetchActivationStatus();
         assertEquals(ActivationStatus.State_Removed, status.state);
+
+        assertNotNull(powerAuthSDK.getLastFetchedActivationStatus());
+        powerAuthSDK.removeActivationLocal(testHelper.getContext());
+        assertNull(powerAuthSDK.getLastFetchedActivationStatus());
     }
 
     @Test

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1397,6 +1397,9 @@ public class PowerAuthSDK {
         clearCachedData();
     }
 
+    /**
+     * Clear in-memory cached data.
+     */
     private void clearCachedData() {
         try {
             mLock.lock();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1393,6 +1393,17 @@ public class PowerAuthSDK {
         saveSerializedState();
         // Cancel possible pending activation status task
         cancelGetActivationStatusTask();
+        // Clear possible cached data
+        clearCachedData();
+    }
+
+    private void clearCachedData() {
+        try {
+            mLock.lock();
+            mLastFetchedActivationStatus = null;
+        } finally {
+            mLock.unlock();
+        }
     }
 
     /**

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -950,6 +950,7 @@ static PowerAuthSDK * s_inst;
 {
     [self checkForValidSetup];
     [self cancelAllPendingTasks];
+    [self clearCachedData];
     [_sessionInterface writeVoidTaskWithSession:^(PowerAuthCoreSession * session) {
         BOOL error = NO;
         if ([_biometryOnlyKeychain containsDataForKey:_biometryKeyIdentifier]) {
@@ -963,6 +964,12 @@ static PowerAuthSDK * s_inst;
     }];
 }
 
+- (void) clearCachedData
+{
+    [_lock lock];
+    _lastFetchedActivationStatus = nil;
+    [_lock unlock];
+}
 
 #pragma mark - Computing signatures
 

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -964,6 +964,9 @@ static PowerAuthSDK * s_inst;
     }];
 }
 
+/**
+ Clear in-memory cached data.
+ */
 - (void) clearCachedData
 {
     [_lock lock];

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKDefaultTests.m
@@ -419,6 +419,11 @@
     // 5) Fetch last status
     status = [_helper fetchActivationStatus];
     XCTAssertEqual(status.state, PowerAuthActivationState_Removed);
+    
+    // Test whether cached activation status is properly removed from memory
+    XCTAssertNotNil(_sdk.lastFetchedActivationStatus);
+    [_sdk removeActivationLocal];
+    XCTAssertNil(_sdk.lastFetchedActivationStatus);
 }
 
 - (void) testActivationStatusConcurrent

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/PowerAuthTestServerConfig.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/PowerAuthTestServerConfig.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(int, PowerAuthTestServerVersion) {
     PATS_V1_2,      // V3.1 crypto + Activation OTP
     PATS_V1_2_5,    // V3.1 crypto + Activation OTP
     PATS_V1_3,      // V3.1 crypto + Activation OTP, applicationId as String
+    PATS_V1_4,      // V3.1 crypto + Activation OTP, applicationId as String
+    PATS_V1_5,      // V3.1 crypto + Activation OTP, applicationId as String, userInfo
 };
 
 /**

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/PowerAuthTestServerConfig.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServerSOAP/PowerAuthTestServerConfig.m
@@ -70,6 +70,8 @@ PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVer)
         case PATS_V1_2:
         case PATS_V1_2_5:
         case PATS_V1_3:
+        case PATS_V1_4:
+        case PATS_V1_5:
             return PATS_P31;
         default:
             // Older versions, defaulting to V2
@@ -98,6 +100,8 @@ PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVer)
             @"1.2"    : @(PATS_V1_2),
             @"1.2.5"  : @(PATS_V1_2_5),
             @"1.3"    : @(PATS_V1_3),
+            @"1.4"    : @(PATS_V1_4),
+            @"1.5"    : @(PATS_V1_5),
          };
     }
     // Remove "V" character from the beginning of the string.


### PR DESCRIPTION
This PR fixes problem with cached data cleanup after activation remove. Also it contains a new definitions for PowerAuth Server versions 1.4 and 1.5.