### PR TITLE
Apple: Fix #510: tvOS SDK is no longer required

### DIFF
--- a/PowerAuth2ForExtensions.podspec
+++ b/PowerAuth2ForExtensions.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = '11.0'
     
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-extensions.sh --out-dir Build/PowerAuth2ForExtensions extensions
+        ./scripts/ios-build-extensions.sh --out-dir Build/PowerAuth2ForExtensions extensions --optional-tvos
     CMD
     
     # Produced files

--- a/PowerAuthCore.podspec
+++ b/PowerAuthCore.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     # XCFramework  build    
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore
+        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos
     CMD
     
     # Produced files

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -48,6 +48,7 @@
    - [Password Strength Indicator](#password-strength-indicator)
    - [Debug Build Detection](#debug-build-detection)
    - [Request Interceptors](#request-interceptors)   
+- [Troubleshooting](#troubleshooting)
 
 Related documents:
 
@@ -1947,3 +1948,14 @@ clientConfig.userAgent = "MyClient/1.0.0"
 The default value of the property is composed as "APP-EXECUTABLE/APP-VERSION PowerAuth2/PA-VERSION (OS/OS-VERSION, DEVICE-INFO)", for example: "MyApp/1.0 PowerAuth2/1.7.0 (iOS 15.2, iPhone12.1)". The information about application executable and version is get from main bundle and its `Info.plist`.
 
 If you set `nil` to the `userAgent` property, then the default "User-Agent" provided by the operating system will be used. 
+
+
+## Troubleshooting
+
+### tvOS support in CocoaPods
+
+The tvOS SDK is not required by default since the SDK version 1.7.7. If your build or development machine doesn't have tvOS SDK installed, then the `PowerAuthCore` module is precompiled with no tvOS platform included in the final xcframework. Due to fact that CocoaPods keep various build artefacts in its cache, then this might be problematic in case you'll add support for tvOS later, during the development. To fix such possible issues, please remove `PowerAuthCore` pod from the cache:
+
+```sh
+pod cache clean 'PowerAuthCore' --all
+```

--- a/scripts/ios-build-extensions.sh
+++ b/scripts/ios-build-extensions.sh
@@ -339,12 +339,13 @@ function DO_BUILD_WATCHOS
 }
 
 # -----------------------------------------------------------------------------
-# Teste whether tvOS SDK is installed locally. Prints "1" to stdout if yes,
+# Test whether tvOS SDK is installed locally. Prints "1" to stdout if yes,
 # otherwise "0".
 # -----------------------------------------------------------------------------
 function FIND_TVOS_SDK
 {
-    PUSH_DIR "$XCODE_DIR"
+    local old_VERBOSE=$VERBOSE; 
+    VERBOSE=0; PUSH_DIR "$XCODE_DIR"
     local project='PowerAuthCore.xcodeproj'
     local scheme='PowerAuthCore_tvOS'
     # This is quite hardcore, but unfortunatelly there's no command line option to test whether SDK is really installed.
@@ -358,7 +359,7 @@ function FIND_TVOS_SDK
         echo "1"    # Grep did not find the requested string, so SDK is not available
     fi
     set -e
-    POP_DIR
+    POP_DIR; VERBOSE=$old_VERBOSE
 }
 
 # -----------------------------------------------------------------------------
@@ -390,12 +391,8 @@ function DO_PATCH_TARGETS
                     use_tvos=0
                 fi
                 ;;
-            1)
-                DEBUG_LOG "tvOS SDK appears to be installed"
-                ;;
-            *)
-                WARNING "Unexpected result from tvOS SDK evaluation: $tvos"
-                ;;
+            1) DEBUG_LOG "tvOS SDK appears to be installed" ;;
+            *) FAILURE "Unexpected result from tvOS SDK evaluation: $tvos" ;;
         esac
     fi
     if [ x$use_tvos == x1 ]; then

--- a/scripts/ios-build-extensions.sh
+++ b/scripts/ios-build-extensions.sh
@@ -35,7 +35,8 @@ XCODE_DIR="${SRC_ROOT}/proj-xcode"
 
 # iOS / tvOS
 EXT_FRAMEWORK="PowerAuth2ForExtensions"
-EXT_PLATFORMS="iOS iOS_Simulator tvOS tvOS_Simulator macOS_Catalyst"
+EXT_PLATFORMS="iOS iOS_Simulator macOS_Catalyst"
+EXT_PLATFORMS_TVOS="tvOS tvOS_Simulator"
 EXT_PROJECT="${XCODE_DIR}/PowerAuth2ForExtensions.xcodeproj"
 # WatchOS
 WOS_FRAMEWORK="PowerAuth2ForWatch"
@@ -52,6 +53,7 @@ OUT_FW=''
 TMP_DIR=''
 OPT_LEGACY_ARCH=0
 OPT_USE_BITCODE=0
+OPT_WEAK_TVOS=0
 DO_WATCHOS=0
 DO_EXTENSIONS=0
 
@@ -74,6 +76,7 @@ function USAGE
     echo ""
     echo "  -nc | --no-clean  disable 'clean' before 'build'"
     echo "                    also disables temporary data cleanup after build"
+    echo "  --optional-tvos   tvOS is not required when SDK is not installed"
     echo "  -v0               turn off all prints to stdout"
     echo "  -v1               print only basic log about build progress"
     echo "  -v2               print full build log with rich debug info"
@@ -335,6 +338,63 @@ function DO_BUILD_WATCHOS
     BUILD_LIBRARY
 }
 
+# -----------------------------------------------------------------------------
+# Teste whether tvOS SDK is installed locally. Prints "1" to stdout if yes,
+# otherwise "0".
+# -----------------------------------------------------------------------------
+function FIND_TVOS_SDK
+{
+    PUSH_DIR "$XCODE_DIR"
+    local project='PowerAuthCore.xcodeproj'
+    local scheme='PowerAuthCore_tvOS'
+    # This is quite hardcore, but unfortunatelly there's no command line option to test whether SDK is really installed.
+    # The idea behind this is that when tvOS SDK is installed, then there are already a some run or build destinations for it.
+    # If tvOS SDK is not installed, then the placeholder SDK is reported, with "not installed" error in the description. 
+    set +e
+    xcodebuild -showdestinations -project $project -scheme $scheme -quiet 2>/dev/null | grep 'not installed' > /dev/null 2>&1;
+    if (($? == 0)); then
+        echo "0"    # Grep found 'not installed' so SDK is not available
+    else
+        echo "1"    # Grep did not find the requested string, so SDK is not available
+    fi
+    set -e
+    POP_DIR
+}
+
+# -----------------------------------------------------------------------------
+# Patch PLATFORMS list depending on the current Xcode capability
+# -----------------------------------------------------------------------------
+function DO_PATCH_TARGETS
+{
+    # tvOS is enforced (the default behavior)
+    local use_tvos=1
+    if (( $(GET_XCODE_VERSION --major) >= 14 )); then
+        # If Xcode version is greater or equal to 14, then additional SDKs are optional
+        if [ $(FIND_TVOS_SDK) == '1' ]; then
+            # The grep did not find the requested string, so SDK is available
+            DEBUG_LOG "tvOS SDK appears to be installed"
+        elif [ x$OPT_WEAK_TVOS == x0 ]; then
+            LOG_LINE
+            LOG "tvOS SDK is optional since Xcode 14 but is required by PowerAuth mobile SDK."
+            LOG "You can use the following solutions to fix this problem:"
+            LOG ""
+            LOG " 1. download all optional platform SDKs:"
+            LOG "      xcodebuild -downloadAllPlatforms"
+            LOG ""
+            LOG " 2. Skip tvOS platform if it's not important to your project:"
+            LOG "      add '--optional-tvos' switch to this build script"
+            LOG_LINE
+            FAILURE "tvOS SDK is not installed."
+        else
+            WARNING "tvOS SDK is not installed, so skipping this platform in the build."
+            use_tvos=0
+        fi
+    fi
+    if [ x$use_tvos == x1 ]; then
+        EXT_PLATFORMS+=" $EXT_PLATFORMS_TVOS"
+    fi
+}
+
 ###############################################################################
 # Script's main execution starts here...
 # -----------------------------------------------------------------------------
@@ -365,6 +425,9 @@ do
         --out-dir)
             OUT_DIR="$2"
             shift
+            ;;
+        --optional-tvos)
+            OPT_WEAK_TVOS=1
             ;;
         -v*)
             SET_VERBOSE_LEVEL_FROM_SWITCH $opt
@@ -409,6 +472,7 @@ $MD "${TMP_DIR}"
 #
 # Build
 #
+[[ x$DO_EXTENSIONS == x1 ]] && DO_PATCH_TARGETS
 [[ x$DO_EXTENSIONS == x1 ]] && DO_BUILD_APPEXT
 [[ x$DO_WATCHOS == x1    ]] && DO_BUILD_WATCHOS
 

--- a/scripts/ios-build-extensions.sh
+++ b/scripts/ios-build-extensions.sh
@@ -370,25 +370,33 @@ function DO_PATCH_TARGETS
     local use_tvos=1
     if (( $(GET_XCODE_VERSION --major) >= 14 )); then
         # If Xcode version is greater or equal to 14, then additional SDKs are optional
-        if [ $(FIND_TVOS_SDK) == '1' ]; then
-            # The grep did not find the requested string, so SDK is available
-            DEBUG_LOG "tvOS SDK appears to be installed"
-        elif [ x$OPT_WEAK_TVOS == x0 ]; then
-            LOG_LINE
-            LOG "tvOS SDK is optional since Xcode 14 but is required by PowerAuth mobile SDK."
-            LOG "You can use the following solutions to fix this problem:"
-            LOG ""
-            LOG " 1. download all optional platform SDKs:"
-            LOG "      xcodebuild -downloadAllPlatforms"
-            LOG ""
-            LOG " 2. Skip tvOS platform if it's not important to your project:"
-            LOG "      add '--optional-tvos' switch to this build script"
-            LOG_LINE
-            FAILURE "tvOS SDK is not installed."
-        else
-            WARNING "tvOS SDK is not installed, so skipping this platform in the build."
-            use_tvos=0
-        fi
+        local tvos=$(FIND_TVOS_SDK)
+        case "$tvos" in
+            0)
+                if [ x$OPT_WEAK_TVOS == x0 ]; then
+                    LOG_LINE
+                    LOG "tvOS SDK is optional since Xcode 14 but is required by PowerAuth mobile SDK."
+                    LOG "You can use the following solutions to fix this problem:"
+                    LOG ""
+                    LOG " 1. download all optional platform SDKs:"
+                    LOG "      xcodebuild -downloadAllPlatforms"
+                    LOG ""
+                    LOG " 2. Skip tvOS platform if it's not important to your project:"
+                    LOG "      add '--optional-tvos' switch to this build script"
+                    LOG_LINE
+                    FAILURE "tvOS SDK is not installed."
+                else
+                    WARNING "tvOS SDK is not installed, so skipping this platform in the build."
+                    use_tvos=0
+                fi
+                ;;
+            1)
+                DEBUG_LOG "tvOS SDK appears to be installed"
+                ;;
+            *)
+                WARNING "Unexpected result from tvOS SDK evaluation: $tvos"
+                ;;
+        esac
     fi
     if [ x$use_tvos == x1 ]; then
         EXT_PLATFORMS+=" $EXT_PLATFORMS_TVOS"

--- a/scripts/ios-build-sdk.sh
+++ b/scripts/ios-build-sdk.sh
@@ -465,25 +465,33 @@ function DO_PATCH_TARGETS
     local use_tvos=1
     if (( $(GET_XCODE_VERSION --major) >= 14 )); then
         # If Xcode version is greater or equal to 14, then additional SDKs are optional
-        if [ $(FIND_TVOS_SDK) == '1' ]; then
-            # The grep did not find the requested string, so SDK is available
-            DEBUG_LOG "tvOS SDK appears to be installed"
-        elif [ x$OPT_WEAK_TVOS == x0 ]; then
-            LOG_LINE
-            LOG "tvOS SDK is optional since Xcode 14 but is required by PowerAuth mobile SDK."
-            LOG "You can use the following solutions to fix this problem:"
-            LOG ""
-            LOG " 1. download all optional platform SDKs:"
-            LOG "      xcodebuild -downloadAllPlatforms"
-            LOG ""
-            LOG " 2. Skip tvOS platform if it's not important to your project:"
-            LOG "      add '--optional-tvos' switch to this build script"
-            LOG_LINE
-            FAILURE "tvOS SDK is not installed."
-        else
-            WARNING "tvOS SDK is not installed, so skipping this platform in the build."
-            use_tvos=0
-        fi
+        local tvos=$(FIND_TVOS_SDK)
+        case "$tvos" in
+            0)
+                if [ x$OPT_WEAK_TVOS == x0 ]; then
+                    LOG_LINE
+                    LOG "tvOS SDK is optional since Xcode 14 but is required by PowerAuth mobile SDK."
+                    LOG "You can use the following solutions to fix this problem:"
+                    LOG ""
+                    LOG " 1. download all optional platform SDKs:"
+                    LOG "      xcodebuild -downloadAllPlatforms"
+                    LOG ""
+                    LOG " 2. Skip tvOS platform if it's not important to your project:"
+                    LOG "      add '--optional-tvos' switch to this build script"
+                    LOG_LINE
+                    FAILURE "tvOS SDK is not installed."
+                else
+                    WARNING "tvOS SDK is not installed, so skipping this platform in the build."
+                    use_tvos=0
+                fi
+                ;;
+            1)
+                DEBUG_LOG "tvOS SDK appears to be installed"
+                ;;
+            *)
+                WARNING "Unexpected result from tvOS SDK evaluation: $tvos"
+                ;;
+        esac
     fi
     if [ x$use_tvos == x1 ]; then
         PLATFORMS+=" $PLATFORMS_TVOS"

--- a/scripts/ios-build-sdk.sh
+++ b/scripts/ios-build-sdk.sh
@@ -434,12 +434,13 @@ function CLEAN_COMMAND
 }
 
 # -----------------------------------------------------------------------------
-# Teste whether tvOS SDK is installed locally. Prints "1" to stdout if yes,
+# Test whether tvOS SDK is installed locally. Prints "1" to stdout if yes,
 # otherwise "0".
 # -----------------------------------------------------------------------------
 function FIND_TVOS_SDK
 {
-    PUSH_DIR "$XCODE_DIR"
+    local old_VERBOSE=$VERBOSE; 
+    VERBOSE=0; PUSH_DIR "$XCODE_DIR"
     local project='PowerAuthCore.xcodeproj'
     local scheme='PowerAuthCore_tvOS'
     # This is quite hardcore, but unfortunatelly there's no command line option to test whether SDK is really installed.
@@ -453,7 +454,7 @@ function FIND_TVOS_SDK
         echo "1"    # Grep did not find the requested string, so SDK is not available
     fi
     set -e
-    POP_DIR
+    POP_DIR; VERBOSE=$old_VERBOSE
 }
 
 # -----------------------------------------------------------------------------
@@ -485,12 +486,8 @@ function DO_PATCH_TARGETS
                     use_tvos=0
                 fi
                 ;;
-            1)
-                DEBUG_LOG "tvOS SDK appears to be installed"
-                ;;
-            *)
-                WARNING "Unexpected result from tvOS SDK evaluation: $tvos"
-                ;;
+            1) DEBUG_LOG "tvOS SDK appears to be installed" ;;
+            *) FAILURE "Unexpected result from tvOS SDK evaluation: $tvos" ;;
         esac
     fi
     if [ x$use_tvos == x1 ]; then

--- a/scripts/templates/PowerAuth2ForExtensions.podspec
+++ b/scripts/templates/PowerAuth2ForExtensions.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = '11.0'
     
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-extensions.sh --out-dir Build/PowerAuth2ForExtensions extensions
+        ./scripts/ios-build-extensions.sh --out-dir Build/PowerAuth2ForExtensions extensions --optional-tvos
     CMD
     
     # Produced files

--- a/scripts/templates/PowerAuthCore.podspec
+++ b/scripts/templates/PowerAuthCore.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     # XCFramework  build    
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore
+        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos
     CMD
     
     # Produced files

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -85,6 +85,10 @@ PUSH_DIR "${SRC_ROOT}"
 ####
 
 LOG_LINE
+LOG "Testing SDK for supported platforms..."
+LOG "  - macOS $(sw_vers -productVersion) ($(uname -m))"
+LOG "  - Xcode $(GET_XCODE_VERSION --full)"
+LOG_LINE
 LOG "Validating shared sources on Apple platform..."
 LOG_LINE
 


### PR DESCRIPTION
This PR changes the default behavior for tvOS platform when library is integrated with CocoaPods. The tvOS SDK is no longer enforced and if it's not installed on the development machine, then the platform is not included in the final `xcframework`.