### PR TITLE
Report BiometryType.GENERIC on broken or new devices

### DIFF
--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1588,11 +1588,13 @@ when (BiometricAuthentication.getBiometryType(context)) {
     BiometryType.NONE ->
         print("Biometry is not supported on the system.")
     BiometryType.GENERIC ->
-        // It's not possible to determine exact type of biometry.
-        // This happens on Android 10+ systems, when the device supports
+        // It's not possible to determine the exact type of biometry.
+        // This occurs on Android 10+ systems when the device supports
         // more than one type of biometric authentication. In this case,
-        // you should use generic terms, like "Authenticate with biometry"
-        // for your UI.
+        // you should use generic terms in your UI, such as "Authenticate with biometry".
+        // This issue can also arise on devices that support a new type of biometry
+        // sensor, or on older, malfunctioning devices that fail to declare 
+        // support for FEATURE_FINGERPRINT.
         print("Biometry type is GENERIC")
     BiometryType.FINGERPRINT ->
         print("Fingerprint scanner is present on the device.")

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TestClass.kt
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TestClass.kt
@@ -1,0 +1,4 @@
+package io.getlime.security.powerauth.integration.tests
+
+class TestClass {
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TestClass.kt
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TestClass.kt
@@ -1,4 +1,0 @@
-package io.getlime.security.powerauth.integration.tests
-
-class TestClass {
-}


### PR DESCRIPTION
If device says that biometric authentication is possible but the type of biometry cannot be determined, then report `BiometryType.GENERIC`. This may happen in two situations:

- Device has a brand new type of sensor not supported in our SDK
- Device is broken, because failed to declare supported set of features, such as `PackageManager.FEATURE_FINGERPRINT`