### PR TITLE
Android: Fix #526: Proguard rules update

### DIFF
--- a/proj-android/PowerAuthLibrary/proguard-rules.pro
+++ b/proj-android/PowerAuthLibrary/proguard-rules.pro
@@ -28,6 +28,6 @@
 -keepclassmembers class io.getlime.core.rest.model.** {
     <fields>;
 }
--keepclassmembers class io.getlime.security.powerauth.networking.model.** {
+-keep class io.getlime.security.powerauth.networking.model.** {
     <fields>;
 }


### PR DESCRIPTION
Keep whole classes instead of class members only in networking.model.**