### PR TITLE
Android: Option to disable error dialog after failed biometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ xcuserdata
 *.xcuserstate
 *.xcscmblueprint
 
+## VSCode
+.vscode
+
 ## Obj-C/Swift specific
 *.hmap
 *.ipa

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1772,7 +1772,7 @@ In order to obtain an encrypted biometry factor-related key for the purpose of a
 <!-- begin codetabs Kotlin Java -->
 ```kotlin
 // Authenticate user with biometry and obtain encrypted biometry factor related key.
-powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometryListener {
+powerAuthSDK.authenticateUsingBiometrics(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometricsListener {
     override fun onBiometricDialogCancelled(userCancel: Boolean) {
         // User cancelled the operation
     }
@@ -1788,7 +1788,7 @@ powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the bi
 ```
 ```java
 // Authenticate user with biometry and obtain encrypted biometry factor related key.
-powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", new IAuthenticateWithBiometryListener() {
+powerAuthSDK.authenticateUsingBiometrics(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", new IAuthenticateWithBiometricsListener() {
     @Override
     public void onBiometricDialogCancelled(boolean userCancel) {
         // User cancelled the operation
@@ -1889,7 +1889,7 @@ When the error dialog is disabled, your application should inform the user of th
 
 ```kotlin
 // Authenticate user with biometry and obtain encrypted biometry factor related key.
-powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometryListener {
+powerAuthSDK.authenticateUsingBiometrics(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometricsListener {
     override fun onBiometricDialogCancelled(userCancel: Boolean) {
         // User or system cancelled the operation
     }

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1772,15 +1772,13 @@ In order to obtain an encrypted biometry factor-related key for the purpose of a
 <!-- begin codetabs Kotlin Java -->
 ```kotlin
 // Authenticate user with biometry and obtain encrypted biometry factor related key.
-powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IBiometricAuthenticationCallback {
+powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometryListener {
     override fun onBiometricDialogCancelled(userCancel: Boolean) {
         // User cancelled the operation
     }
 
-    override fun onBiometricDialogSuccess(biometricKeyData: BiometricKeyData) {
-        // User authenticated and biometry key was returned, now you can construct PowerAuthAuthentication object with proper signing capabilities.
-        val biometryFactorRelatedKey = biometricKeyData.derivedData
-        val twoFactorBiometry = PowerAuthAuthentication.possessionWithBiometry(biometryFactorRelatedKey)
+    override fun onBiometricDialogSuccess(authentication: PowerAuthAuthentication) {
+        // User authenticated use the provided authentication object for other tasks.
     }
 
     override fun onBiometricDialogFailed(error: PowerAuthErrorException) {
@@ -1790,17 +1788,15 @@ powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the bi
 ```
 ```java
 // Authenticate user with biometry and obtain encrypted biometry factor related key.
-powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", new IBiometricAuthenticationCallback() {
+powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", new IAuthenticateWithBiometryListener() {
     @Override
     public void onBiometricDialogCancelled(boolean userCancel) {
         // User cancelled the operation
     }
 
     @Override
-    public void onBiometricDialogSuccess(BiometricKeyData biometricKeyData) {
-        // User authenticated and biometry key was returned, now you can construct PowerAuthAuthentication object with proper signing capabilities.
-        final byte[] biometryFactorRelatedKey = biometricKeyData.getDerivedData();
-        final PowerAuthAuthentication twoFactorBiometry = PowerAuthAuthentication.possessionWithBiometry(biometryFactorRelatedKey);
+    public void onBiometricDialogSuccess(PowerAuthAuthentication authentication) {
+        // User authenticated use the provided authentication object for other tasks.
     }
 
     @Override
@@ -1848,6 +1844,8 @@ Be aware that the configuration above is effective only for the new keys. So, if
 
 The `BiometricAuthentication` class is a high level interface that provides interfaces related to the biometric authentication for the SDK, or for the application purposes. The class hides all technical details, so it can be safely used also on the systems that doesn't provide biometric interfaces, or if the system has no biometric sensor available. The implementation under the hood uses `androidx.biometric.BiometricPrompt` and `androidx.biometric.BiometricManager` classes.
 
+#### Customize Biometric Dialog Resources 
+
 To customize the strings used in biometric authentication, you can use `BiometricDialogResources` in the following manner:
 
 <!-- begin codetabs Kotlin Java -->
@@ -1878,6 +1876,44 @@ final BiometricDialogResources resources = new BiometricDialogResources.Builder(
 BiometricAuthentication.setBiometricDialogResources(resources);
 ```
 <!-- end -->
+
+#### Disable Error Dialog After Failed Biometry
+
+If you prefer not to allow the PowerAuth mobile SDK to display its own error dialog, you can disable this feature globally. In this case, your application will need to handle all error situations through its own user interface. Use the following code to disable the error dialog:
+
+```kotlin
+BiometricAuthentication.setBiometricErrorDialogDisabled(true)
+```
+
+When the error dialog is disabled, your application should inform the user of the reason for the failure. Handling this might be somewhat tricky because there are situations where the biometric authentication dialog is not displayed at all, and the failure is reported directly to the application. To address this, you can use the `BiometricErrorInfo` enumeration, which is associated with the reported `PowerAuthErrorException`. The code snippet below outlines how to determine the situation:
+
+```kotlin
+// Authenticate user with biometry and obtain encrypted biometry factor related key.
+powerAuthSDK.authenticateUsingBiometry(context, fragment, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometryListener {
+    override fun onBiometricDialogCancelled(userCancel: Boolean) {
+        // User or system cancelled the operation
+    }
+
+    override fun onBiometricDialogSuccess(authentication: PowerAuthAuthentication) {
+        // Success
+    }
+
+    override fun onBiometricDialogFailed(error: PowerAuthErrorException) {
+        if (error.additionalInformation == BiometricErrorInfo.BIOMETRICS_FAILED_WITH_NO_VISIBLE_REASON) {
+            // Application should display error in its own UI
+            when (error.powerAuthErrorCode) {
+                PowerAuthErrorCodes.BIOMETRY_LOCKOUT -> println("Lockout")
+                PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE -> println("Not available, try later")
+                PowerAuthErrorCodes.BIOMETRY_NOT_RECOGNIZED -> println("Fingerprint or face not recognized") // check inline documentation for more details
+                PowerAuthErrorCodes.BIOMETRY_NOT_SUPPORTED -> println("Device has no biometry sensor")
+                PowerAuthErrorCodes.BIOMETRY_NOT_ENROLLED -> println("Device has no biometry data enrolled")
+            }
+        }
+    }
+})
+```
+
+#### Biometric Authentication Confirmation
 
 On Android 10+ systems, it's possible to configure `BiometricPrompt` to ask for an additional confirmation after the user is successfully authenticated. The default behavior for PowerAuth Mobile SDK is that such confirmation is not required. To change this behavior, you have to provide `PowerAuthKeychainConfiguration` object with `confirmBiometricAuthentication` parameter set to `true` and use that configuration for the `PowerAuthSDK` instance construction:
 
@@ -2559,6 +2595,7 @@ when (t) {
             PowerAuthErrorCodes.BIOMETRY_NOT_SUPPORTED -> Log.d(TAG, "The device or operating system doesn't support biometric authentication.")
             PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE -> Log.d(TAG, "The biometric authentication is temporarily unavailable.")
             PowerAuthErrorCodes.BIOMETRY_NOT_RECOGNIZED -> Log.d(TAG, "The biometric authentication did not recognize the biometric image (fingerprint, face, etc...)")
+            PowerAuthErrorCodes.BIOMETRY_NOT_ENROLLED -> Log.d(TAG, "The biometric authentication failed because there's no biometry enrolled")
             PowerAuthErrorCodes.BIOMETRY_LOCKOUT -> Log.d(TAG, "The biometric authentication is locked out due to too many failed attempts.")
             PowerAuthErrorCodes.OPERATION_CANCELED -> Log.d(TAG, "Error code for cancelled operations")
             PowerAuthErrorCodes.ENCRYPTION_ERROR -> Log.d(TAG, "Error code for errors related to end-to-end encryption")
@@ -2566,6 +2603,13 @@ when (t) {
             PowerAuthErrorCodes.PROTOCOL_UPGRADE -> Log.d(TAG, "Error code for error that occurs when protocol upgrade fails at unrecoverable error.")
             PowerAuthErrorCodes.PENDING_PROTOCOL_UPGRADE -> Log.d(TAG, "The operation is temporarily unavailable, due to pending protocol upgrade.")
             PowerAuthErrorCodes.TIME_SYNCHRONIZATION -> Log.d(TAG, "Failed to synchronize time with the server.")
+        }
+        // Process additional information
+        when (t.additionalInformation) {
+            BiometricErrorInfo.BIOMETRICS_FAILED_WITH_NO_VISIBLE_REASON -> {
+                // Application should display error dialog after failed biometric authentication. This is relevant only
+                // if you disabled the biometric error dialog provided by PowerAuth mobile SDK.
+            }
         }
     }
     is ErrorResponseApiException -> {
@@ -2609,6 +2653,8 @@ if (t instanceof PowerAuthErrorException) {
             android.util.Log.d(TAG,"The biometric authentication is temporarily unavailable."); break;
         case PowerAuthErrorCodes.BIOMETRY_NOT_RECOGNIZED:
             android.util.Log.d(TAG,"The biometric authentication did not recognize the biometric image (fingerprint, face, etc...)"); break;
+        case PowerAuthErrorCodes.BIOMETRY_NOT_ENROLLED:
+            android.util.Log.d(TAG,"The biometric authentication failed because there's no biometry enrolled"); break;
         case PowerAuthErrorCodes.BIOMETRY_LOCKOUT:
             android.util.Log.d(TAG,"The biometric authentication is locked out due to too many failed attempts."); break;
         case PowerAuthErrorCodes.OPERATION_CANCELED:
@@ -2624,6 +2670,12 @@ if (t instanceof PowerAuthErrorException) {
         case PowerAuthErrorCodes.TIME_SYNCHRONIZATION:
             android.util.Log.d(TAG,"Failed to synchronize time with the server."); break;
     }
+    // Process additional information
+    if (BiometricErrorInfo.BIOMETRICS_FAILED_WITH_NO_VISIBLE_REASON.equals(exception.getAdditionalInformation())) {
+        // Application should display error dialog after failed biometric authentication. This is relevant only
+        // if you disabled the biometric error dialog provided by PowerAuth mobile SDK.
+    }
+
 } else if (t instanceof ErrorResponseApiException) {
     ErrorResponseApiException exception = (ErrorResponseApiException) t;
     Error errorResponse = exception.getErrorResponse();

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -597,7 +597,7 @@ This code has created activation with two factors: possession (key stored using 
 <!-- begin codetabs Kotlin Java -->
 ```kotlin
 // Persist activation using given PIN and ad-hoc generated biometric related key
-powerAuthSDK.persistActivation(context, fragment, "Enable Biometric Authentication", "To enable biometric authentication, use the biometric sensor on your device.", pin, object: IPersistActivationWithBiometryListener {
+powerAuthSDK.persistActivation(context, fragment, "Enable Biometric Authentication", "To enable biometric authentication, use the biometric sensor on your device.", pin, object: IPersistActivationWithBiometricsListener {
     override fun onBiometricDialogCancelled() {
         // Biometric enrolment cancelled by user
     }
@@ -613,7 +613,7 @@ powerAuthSDK.persistActivation(context, fragment, "Enable Biometric Authenticati
 ```
 ```java
 // Persist activation using given PIN and ad-hoc generated biometric related key
-powerAuthSDK.persistActivation(context, fragment, "Enable Biometric Authentication", "To enable biometric authentication, use the biometric sensor on your device.", pin, new IPersistActivationWithBiometryListener() {
+powerAuthSDK.persistActivation(context, fragment, "Enable Biometric Authentication", "To enable biometric authentication, use the biometric sensor on your device.", pin, new IPersistActivationWithBiometricsListener() {
     @Override
     public void onBiometricDialogCancelled() {
         // Biometric enrolment cancelled by user

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricErrorInfo.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricErrorInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.biometry;
+
+import androidx.annotation.NonNull;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+
+/**
+ * The {@code BiometricErrorInfo} enumeration contains an information associated with {@link PowerAuthErrorException}.
+ * The enumeration is available only if the exception's error code is one of:
+ * <ul>
+ *     <li>{@link PowerAuthErrorCodes#BIOMETRY_LOCKOUT}</li>
+ *     <li>{@link PowerAuthErrorCodes#BIOMETRY_NOT_AVAILABLE}</li>
+ *     <li>{@link PowerAuthErrorCodes#BIOMETRY_NOT_RECOGNIZED}</li>
+ *     <li>{@link PowerAuthErrorCodes#BIOMETRY_NOT_SUPPORTED}</li>
+ *     <li>{@link PowerAuthErrorCodes#BIOMETRY_NOT_ENROLLED}</li>
+ * </ul>
+ */
+public enum BiometricErrorInfo {
+    /**
+     * The biometric authentication failed and the reason of failure was already displayed in the authentication dialog.
+     */
+    BIOMETRICS_FAILED_WITH_VISIBLE_REASON,
+    /**
+     * The biometric authentication failed and the reason of failure was not displayed in the authentication dialog.
+     * In this case, application should properly investigate the reason of the failure and display an appropriate
+     * error information.
+     */
+    BIOMETRICS_FAILED_WITH_NO_VISIBLE_REASON
+    ;
+
+    /**
+     * If the provided exception is biometry-related, then create a new instance of {@link PowerAuthErrorException}
+     * with the same error code, message and cause and use this enumeration as a source of additional information.
+     * THe additional information can be later retrieved with {@link PowerAuthErrorException#getAdditionalInformation()}.
+     * @param exception Exception to enhance.
+     * @return new exception enhanced with additional information or the original exception if it's not biometry-related.
+     */
+    @NonNull
+    public PowerAuthErrorException addToException(@NonNull PowerAuthErrorException exception) {
+        final int errorCode = exception.getPowerAuthErrorCode();
+        if (errorCode == PowerAuthErrorCodes.BIOMETRY_LOCKOUT ||
+                errorCode == PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE ||
+                errorCode == PowerAuthErrorCodes.BIOMETRY_NOT_RECOGNIZED ||
+                errorCode == PowerAuthErrorCodes.BIOMETRY_NOT_SUPPORTED ||
+                errorCode == PowerAuthErrorCodes.BIOMETRY_NOT_ENROLLED) {
+            return new PowerAuthErrorException(errorCode, exception.getMessage(), exception.getCause(), this);
+        }
+        return exception;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAuthenticateWithBiometricsListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAuthenticateWithBiometricsListener.java
@@ -24,7 +24,7 @@ import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 /**
  * Interface used as a callback for biometric authentication for general application use.
  */
-public interface IAuthenticateWithBiometryListener {
+public interface IAuthenticateWithBiometricsListener {
     /**
      * Biometric authentication dialog was cancelled by the user or externally, by calling {@code cancel()}
      * on cancelable object returned from authenticate() method.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAuthenticateWithBiometryListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IAuthenticateWithBiometryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Wultra s.r.o.
+ * Copyright 2023 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,13 @@ package io.getlime.security.powerauth.biometry;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
-
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 
 /**
- * Interface used as a callback for biometric authentication for an internal SDK purposes.
+ * Interface used as a callback for biometric authentication for general application use.
  */
-public interface IBiometricAuthenticationCallback {
-
+public interface IAuthenticateWithBiometryListener {
     /**
      * Biometric authentication dialog was cancelled by the user or externally, by calling {@code cancel()}
      * on cancelable object returned from authenticate() method.
@@ -40,11 +39,10 @@ public interface IBiometricAuthenticationCallback {
     /**
      * Biometric authentication succeeded.
      *
-     * @param biometricKeyData {@link BiometricKeyData} object with derived key and data that should
-     *                         be stored to the persistent storage.
+     * @param authentication {@link PowerAuthAuthentication} configured for combination of possession and biometry factors.
      */
     @UiThread
-    void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData);
+    void onBiometricDialogSuccess(@NonNull PowerAuthAuthentication authentication);
 
     /**
      * Biometric authentication failed with the error.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/ICommitActivationWithBiometryListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/ICommitActivationWithBiometryListener.java
@@ -18,8 +18,8 @@ package io.getlime.security.powerauth.biometry;
 
 /**
  * Interface used as a callback for persisting the activation with biometric authentication.
- * @deprecated Use {@link IPersistActivationWithBiometryListener} as a replacement.
+ * @deprecated Use {@link IPersistActivationWithBiometricsListener} as a replacement.
  */
 @Deprecated // 1.8.0
-public interface ICommitActivationWithBiometryListener extends IPersistActivationWithBiometryListener {
+public interface ICommitActivationWithBiometryListener extends IPersistActivationWithBiometricsListener {
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IPersistActivationWithBiometricsListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IPersistActivationWithBiometricsListener.java
@@ -22,7 +22,7 @@ import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 /**
  * Interface used as a callback for persisting the activation with biometric authentication.
  */
-public interface IPersistActivationWithBiometryListener {
+public interface IPersistActivationWithBiometricsListener {
     /**
      * Biometric dialog was cancelled.
      */

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/PrivateRequestData.java
@@ -34,6 +34,7 @@ public class PrivateRequestData {
     private final @NonNull BiometricResultDispatcher dispatcher;
     private final @NonNull BiometricDialogResources resources;
     private final @NonNull IBiometricKeyEncryptorProvider biometricKeyEncryptorProvider;
+    private final boolean errorDialogDisabled;
     private final long creationTime;
 
     /**
@@ -43,16 +44,19 @@ public class PrivateRequestData {
      * @param biometricKeyEncryptorProvider Object that provide {@link IBiometricKeyEncryptor} on demand.
      * @param dispatcher Dispatcher that holds completion callback and callback dispatcher.
      * @param resources Resources required for the legacy implementation.
+     * @param errorDialogDisabled If true then error dialog should not be displayed.
      */
     public PrivateRequestData(@NonNull BiometricAuthenticationRequest request,
                               @NonNull IBiometricKeyEncryptorProvider biometricKeyEncryptorProvider,
                               @NonNull BiometricResultDispatcher dispatcher,
-                              @NonNull BiometricDialogResources resources) {
+                              @NonNull BiometricDialogResources resources,
+                              boolean errorDialogDisabled) {
         this.request = request;
         this.biometricKeyEncryptorProvider = biometricKeyEncryptorProvider;
         this.dispatcher = dispatcher;
         this.resources = resources;
         this.creationTime = SystemClock.elapsedRealtime();
+        this.errorDialogDisabled = errorDialogDisabled;
     }
 
     /**
@@ -88,6 +92,13 @@ public class PrivateRequestData {
      */
     public long getElapsedTime() {
         return SystemClock.elapsedRealtime() - creationTime;
+    }
+
+    /**
+     * @return {@code true} if error dialog after failed authentication should not be displayed.
+     */
+    public boolean isErrorDialogDisabled() {
+        return errorDialogDisabled;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
@@ -33,7 +33,8 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
         INVALID_TOKEN, ENCRYPTION_ERROR, WRONG_PARAMETER,
         PROTOCOL_UPGRADE, PENDING_PROTOCOL_UPGRADE,
         BIOMETRY_NOT_SUPPORTED, BIOMETRY_NOT_AVAILABLE, BIOMETRY_NOT_RECOGNIZED,
-        INSUFFICIENT_KEYCHAIN_PROTECTION, BIOMETRY_LOCKOUT, TIME_SYNCHRONIZATION})
+        INSUFFICIENT_KEYCHAIN_PROTECTION, BIOMETRY_LOCKOUT, TIME_SYNCHRONIZATION,
+        BIOMETRY_NOT_ENROLLED})
 public @interface PowerAuthErrorCodes {
 
     /**
@@ -162,4 +163,9 @@ public @interface PowerAuthErrorCodes {
      * Failed to synchronize time with the server.
      */
     int TIME_SYNCHRONIZATION = 23;
+
+    /**
+     * The biometric authentication failed because there's no biometry enrolled on the device.
+     */
+    int BIOMETRY_NOT_ENROLLED = 24;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.exception;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Will be thrown, or will be returned to listener, in case that requested operation fails
@@ -29,12 +30,17 @@ public class PowerAuthErrorException extends Exception {
      */
     @PowerAuthErrorCodes
     private final int powerAuthErrorCode;
+    /**
+     * Additional information associated with the failure reason. The m
+     */
+    private final Object additionalInformation;
 
     /**
      * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}
      */
     public PowerAuthErrorException(@PowerAuthErrorCodes int powerAuthErrorCode) {
         this.powerAuthErrorCode = powerAuthErrorCode;
+        this.additionalInformation = null;
     }
 
     /**
@@ -44,6 +50,7 @@ public class PowerAuthErrorException extends Exception {
     public PowerAuthErrorException(@PowerAuthErrorCodes int powerAuthErrorCode, String message) {
         super(message);
         this.powerAuthErrorCode = powerAuthErrorCode;
+        this.additionalInformation = null;
     }
 
     /**
@@ -54,6 +61,19 @@ public class PowerAuthErrorException extends Exception {
     public PowerAuthErrorException(@PowerAuthErrorCodes int powerAuthErrorCode, String message, Throwable cause) {
         super(message, cause);
         this.powerAuthErrorCode = powerAuthErrorCode;
+        this.additionalInformation = null;
+    }
+
+    /**
+     * @param powerAuthErrorCode Integer constant from {@link PowerAuthErrorCodes}
+     * @param message String with detailed error description.
+     * @param cause Original cause of failure.
+     * @param additionalInformation Additional information.
+     */
+    public PowerAuthErrorException(@PowerAuthErrorCodes int powerAuthErrorCode, String message, Throwable cause, Object additionalInformation) {
+        super(message, cause);
+        this.powerAuthErrorCode = powerAuthErrorCode;
+        this.additionalInformation = additionalInformation;
     }
 
     /**
@@ -62,6 +82,16 @@ public class PowerAuthErrorException extends Exception {
     @PowerAuthErrorCodes
     public int getPowerAuthErrorCode() {
         return powerAuthErrorCode;
+    }
+
+    /**
+     * Get additional information that may help with the error processing. If the error is biometry-related, then
+     * you can obtain {@link io.getlime.security.powerauth.biometry.BiometricErrorInfo} enumeration in this property.
+     * @return Additional information that help with error processing.
+     */
+    @Nullable
+    public Object getAdditionalInformation() {
+        return additionalInformation;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IGenerateTokenHeaderListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IGenerateTokenHeaderListener.java
@@ -26,6 +26,8 @@ import io.getlime.security.powerauth.sdk.PowerAuthAuthorizationHttpHeader;
 public interface IGenerateTokenHeaderListener {
     /**
      * Called when generating token header succeeded.
+     *
+     * @param header Authorization header.
      */
     @MainThread
     void onGenerateTokenHeaderSucceeded(@NonNull PowerAuthAuthorizationHttpHeader header);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IServerStatusListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IServerStatusListener.java
@@ -25,6 +25,8 @@ import androidx.annotation.NonNull;
 public interface IServerStatusListener {
     /**
      * Called when getting server status succeeded.
+     *
+     * @param status Received server status.
      */
     @MainThread
     void onServerStatusSucceeded(@NonNull ServerStatus status);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
@@ -16,15 +16,12 @@
 
 package io.getlime.security.powerauth.sdk;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 
 import io.getlime.security.powerauth.core.SessionSetup;
-import io.getlime.security.powerauth.sdk.impl.IPossessionFactorEncryptionKeyProvider;
 
 /**
  * Class representing a configuration of a single PowerAuthSDK instance.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -940,8 +940,8 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final String password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
-        return persistActivationWithBiometryImpl(context, FragmentHelper.from(fragmentActivity), title, description, new Password(password), callback);
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
+        return persistActivationWithBiometricsImpl(context, FragmentHelper.from(fragmentActivity), title, description, new Password(password), callback);
     }
 
     /**
@@ -963,8 +963,8 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final Password password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
-        return persistActivationWithBiometryImpl(context, FragmentHelper.from(fragmentActivity), title, description, password, callback);
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
+        return persistActivationWithBiometricsImpl(context, FragmentHelper.from(fragmentActivity), title, description, password, callback);
     }
 
     /**
@@ -986,8 +986,8 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final String password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
-        return persistActivationWithBiometryImpl(context, FragmentHelper.from(fragment), title, description, new Password(password), callback);
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
+        return persistActivationWithBiometricsImpl(context, FragmentHelper.from(fragment), title, description, new Password(password), callback);
     }
 
     /**
@@ -1009,8 +1009,8 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final Password password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
-        return persistActivationWithBiometryImpl(context, FragmentHelper.from(fragment), title, description, password, callback);
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
+        return persistActivationWithBiometricsImpl(context, FragmentHelper.from(fragment), title, description, password, callback);
     }
 
     /**
@@ -1026,13 +1026,13 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    private ICancelable persistActivationWithBiometryImpl(
+    private ICancelable persistActivationWithBiometricsImpl(
             final @NonNull Context context,
             @NonNull FragmentHelper fragmentHelper,
             @NonNull String title,
             @NonNull String description,
             @NonNull final Password password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
         return authenticateUsingBiometrics(context, fragmentHelper, title, description, true, new IBiometricAuthenticationCallback() {
             @Override
             public void onBiometricDialogCancelled(boolean userCancel) {
@@ -1237,7 +1237,7 @@ public class PowerAuthSDK {
      * @param password Password used to persist activation.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #persistActivation(Context, Fragment, String, String, Password, IPersistActivationWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #persistActivation(Context, Fragment, String, String, Password, IPersistActivationWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -1248,7 +1248,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final Password password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
         return persistActivation(context, fragment, title, description, password, callback);
     }
 
@@ -1262,7 +1262,7 @@ public class PowerAuthSDK {
      * @param password Password used to persist activation.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #persistActivation(Context, Fragment, String, String, String, IPersistActivationWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #persistActivation(Context, Fragment, String, String, String, IPersistActivationWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -1273,7 +1273,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final String password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
         return persistActivation(context, fragment, title, description, password, callback);
     }
 
@@ -1287,7 +1287,7 @@ public class PowerAuthSDK {
      * @param password Password used to persist activation.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #persistActivation(Context, FragmentActivity, String, String, String, IPersistActivationWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #persistActivation(Context, FragmentActivity, String, String, String, IPersistActivationWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -1298,7 +1298,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final String password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
         return persistActivation(context, fragmentActivity, title, description, password, callback);
     }
 
@@ -1312,7 +1312,7 @@ public class PowerAuthSDK {
      * @param password Password used to persist activation.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #persistActivation(Context, FragmentActivity, String, String, Password, IPersistActivationWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #persistActivation(Context, FragmentActivity, String, String, Password, IPersistActivationWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -1323,7 +1323,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             @NonNull final Password password,
-            final @NonNull IPersistActivationWithBiometryListener callback) {
+            final @NonNull IPersistActivationWithBiometricsListener callback) {
         return persistActivation(context, fragmentActivity, title, description, password, callback);
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1033,7 +1033,7 @@ public class PowerAuthSDK {
             @NonNull String description,
             @NonNull final Password password,
             final @NonNull IPersistActivationWithBiometryListener callback) {
-        return authenticateUsingBiometry(context, fragmentHelper, title, description, true, new IBiometricAuthenticationCallback() {
+        return authenticateUsingBiometrics(context, fragmentHelper, title, description, true, new IBiometricAuthenticationCallback() {
             @Override
             public void onBiometricDialogCancelled(boolean userCancel) {
                 if (userCancel) {
@@ -2067,7 +2067,7 @@ public class PowerAuthSDK {
             public void onFetchEncryptedVaultUnlockKeySucceed(final String encryptedEncryptionKey) {
                 if (encryptedEncryptionKey != null) {
                     // Authenticate using biometry to generate a key
-                    final ICancelable biometricAuthentication = authenticateUsingBiometry(context, fragmentHelper, title, description, true, new IBiometricAuthenticationCallback() {
+                    final ICancelable biometricAuthentication = authenticateUsingBiometrics(context, fragmentHelper, title, description, true, new IBiometricAuthenticationCallback() {
                         @Override
                         public void onBiometricDialogCancelled(boolean userCancel) {
                             if (userCancel) {
@@ -2302,7 +2302,7 @@ public class PowerAuthSDK {
 
     /**
      * Authenticate a client using biometric authentication. In case of the authentication is successful and
-     * {@link IAuthenticateWithBiometryListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
+     * {@link IAuthenticateWithBiometricsListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
      *
      * @param context Context.
      * @param fragment The fragment of the application that will host the prompt.
@@ -2313,18 +2313,18 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    public ICancelable authenticateUsingBiometry(
+    public ICancelable authenticateUsingBiometrics(
             @NonNull Context context,
             @NonNull Fragment fragment,
             @NonNull String title,
             @NonNull String description,
-            final @NonNull IAuthenticateWithBiometryListener listener) {
-        return authenticateUsingBiometry(context, FragmentHelper.from(fragment), title, description, false, getBiometricCallbackWithListener(listener));
+            final @NonNull IAuthenticateWithBiometricsListener listener) {
+        return authenticateUsingBiometrics(context, FragmentHelper.from(fragment), title, description, false, getBiometricCallbackWithListener(listener));
     }
 
     /**
      * Authenticate a client using biometric authentication. In case of the authentication is successful and
-     * {@link IAuthenticateWithBiometryListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
+     * {@link IAuthenticateWithBiometricsListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
      *
      * @param context Context.
      * @param fragmentActivity The activity of the application that will host the prompt.
@@ -2335,13 +2335,13 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    public ICancelable authenticateUsingBiometry(
+    public ICancelable authenticateUsingBiometrics(
             @NonNull Context context,
             @NonNull FragmentActivity fragmentActivity,
             @NonNull String title,
             @NonNull String description,
-            final @NonNull IAuthenticateWithBiometryListener listener) {
-        return authenticateUsingBiometry(context, FragmentHelper.from(fragmentActivity), title, description, false, getBiometricCallbackWithListener(listener));
+            final @NonNull IAuthenticateWithBiometricsListener listener) {
+        return authenticateUsingBiometrics(context, FragmentHelper.from(fragmentActivity), title, description, false, getBiometricCallbackWithListener(listener));
     }
 
     /**
@@ -2350,7 +2350,7 @@ public class PowerAuthSDK {
      * @return Instance of {@link IBiometricAuthenticationCallback}.
      */
     @NonNull
-    private IBiometricAuthenticationCallback getBiometricCallbackWithListener(@NonNull IAuthenticateWithBiometryListener listener) {
+    private IBiometricAuthenticationCallback getBiometricCallbackWithListener(@NonNull IAuthenticateWithBiometricsListener listener) {
         return new IBiometricAuthenticationCallback() {
             @Override
             public void onBiometricDialogCancelled(boolean userCancel) {
@@ -2380,7 +2380,7 @@ public class PowerAuthSDK {
      * @param description Dialog description.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #authenticateUsingBiometry(Context, Fragment, String, String, IAuthenticateWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #authenticateUsingBiometrics(Context, Fragment, String, String, IAuthenticateWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -2391,7 +2391,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             final @NonNull IBiometricAuthenticationCallback callback) {
-        return authenticateUsingBiometry(context, FragmentHelper.from(fragment), title, description, false, callback);
+        return authenticateUsingBiometrics(context, FragmentHelper.from(fragment), title, description, false, callback);
     }
 
     /**
@@ -2404,7 +2404,7 @@ public class PowerAuthSDK {
      * @param description Dialog description.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
-     * @deprecated Use {@link #authenticateUsingBiometry(Context, FragmentActivity, String, String, IAuthenticateWithBiometryListener)} as a replacement.
+     * @deprecated Use {@link #authenticateUsingBiometrics(Context, FragmentActivity, String, String, IAuthenticateWithBiometricsListener)} as a replacement.
      */
     @UiThread
     @NonNull
@@ -2415,7 +2415,7 @@ public class PowerAuthSDK {
             @NonNull String title,
             @NonNull String description,
             final @NonNull IBiometricAuthenticationCallback callback) {
-        return authenticateUsingBiometry(context, FragmentHelper.from(fragmentActivity), title, description, false, callback);
+        return authenticateUsingBiometrics(context, FragmentHelper.from(fragmentActivity), title, description, false, callback);
     }
 
     /**
@@ -2431,7 +2431,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    private ICancelable authenticateUsingBiometry(
+    private ICancelable authenticateUsingBiometrics(
             final @NonNull Context context,
             final @NonNull FragmentHelper fragmentHelper,
             final @NonNull String title,

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -2301,8 +2301,78 @@ public class PowerAuthSDK {
     }
 
     /**
-     * Authenticate a client using biometric authentication. In case of the authentication is successful and {@link IBiometricAuthenticationCallback#onBiometricDialogSuccess(BiometricKeyData)} callback is called,
-     * you can use {@code biometricKeyEncrypted} as a parameter to {@link PowerAuthAuthentication#useBiometry} property.
+     * Authenticate a client using biometric authentication. In case of the authentication is successful and
+     * {@link IAuthenticateWithBiometryListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
+     *
+     * @param context Context.
+     * @param fragment The fragment of the application that will host the prompt.
+     * @param title Dialog title.
+     * @param description Dialog description.
+     * @param listener Callback with the authentication result.
+     * @return {@link ICancelable} object associated with the biometric prompt.
+     */
+    @UiThread
+    @NonNull
+    public ICancelable authenticateUsingBiometry(
+            @NonNull Context context,
+            @NonNull Fragment fragment,
+            @NonNull String title,
+            @NonNull String description,
+            final @NonNull IAuthenticateWithBiometryListener listener) {
+        return authenticateUsingBiometry(context, FragmentHelper.from(fragment), title, description, false, getBiometricCallbackWithListener(listener));
+    }
+
+    /**
+     * Authenticate a client using biometric authentication. In case of the authentication is successful and
+     * {@link IAuthenticateWithBiometryListener#onBiometricDialogSuccess(PowerAuthAuthentication)} callback is called.
+     *
+     * @param context Context.
+     * @param fragmentActivity The activity of the application that will host the prompt.
+     * @param title Dialog title.
+     * @param description Dialog description.
+     * @param listener Callback with the authentication result.
+     * @return {@link ICancelable} object associated with the biometric prompt.
+     */
+    @UiThread
+    @NonNull
+    public ICancelable authenticateUsingBiometry(
+            @NonNull Context context,
+            @NonNull FragmentActivity fragmentActivity,
+            @NonNull String title,
+            @NonNull String description,
+            final @NonNull IAuthenticateWithBiometryListener listener) {
+        return authenticateUsingBiometry(context, FragmentHelper.from(fragmentActivity), title, description, false, getBiometricCallbackWithListener(listener));
+    }
+
+    /**
+     * Create low level biometric authentication callback that bridge the result to the provided listener.
+     * @param listener Target listener.
+     * @return Instance of {@link IBiometricAuthenticationCallback}.
+     */
+    @NonNull
+    private IBiometricAuthenticationCallback getBiometricCallbackWithListener(@NonNull IAuthenticateWithBiometryListener listener) {
+        return new IBiometricAuthenticationCallback() {
+            @Override
+            public void onBiometricDialogCancelled(boolean userCancel) {
+                listener.onBiometricDialogCancelled(userCancel);
+            }
+
+            @Override
+            public void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData) {
+                final PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithBiometry(biometricKeyData.getDerivedData());
+                listener.onBiometricDialogSuccess(authentication);
+            }
+
+            @Override
+            public void onBiometricDialogFailed(@NonNull PowerAuthErrorException error) {
+                listener.onBiometricDialogFailed(error);
+            }
+        };
+    }
+
+    /**
+     * Authenticate a client using biometric authentication. In case of the authentication is successful and
+     * {@link IBiometricAuthenticationCallback#onBiometricDialogSuccess(BiometricKeyData)} callback is called.
      *
      * @param context Context.
      * @param fragment The fragment of the application that will host the prompt.
@@ -2310,9 +2380,11 @@ public class PowerAuthSDK {
      * @param description Dialog description.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
+     * @deprecated Use {@link #authenticateUsingBiometry(Context, Fragment, String, String, IAuthenticateWithBiometryListener)} as a replacement.
      */
     @UiThread
     @NonNull
+    @Deprecated // 1.8.0
     public ICancelable authenticateUsingBiometry(
             @NonNull Context context,
             @NonNull Fragment fragment,
@@ -2323,8 +2395,8 @@ public class PowerAuthSDK {
     }
 
     /**
-     * Authenticate a client using biometric authentication. In case of the authentication is successful and {@link IBiometricAuthenticationCallback#onBiometricDialogSuccess(BiometricKeyData)} callback is called,
-     * you can use {@code biometricKeyEncrypted} as a parameter to {@link PowerAuthAuthentication#useBiometry} property.
+     * Authenticate a client using biometric authentication. In case of the authentication is successful and
+     * {@link IBiometricAuthenticationCallback#onBiometricDialogSuccess(BiometricKeyData)} callback is called,
      *
      * @param context Context.
      * @param fragmentActivity The activity of the application that will host the prompt.
@@ -2332,9 +2404,11 @@ public class PowerAuthSDK {
      * @param description Dialog description.
      * @param callback Callback with the authentication result.
      * @return {@link ICancelable} object associated with the biometric prompt.
+     * @deprecated Use {@link #authenticateUsingBiometry(Context, FragmentActivity, String, String, IAuthenticateWithBiometryListener)} as a replacement.
      */
     @UiThread
     @NonNull
+    @Deprecated // 1.8.0
     public ICancelable authenticateUsingBiometry(
             @NonNull Context context,
             @NonNull FragmentActivity fragmentActivity,
@@ -2345,8 +2419,7 @@ public class PowerAuthSDK {
     }
 
     /**
-     * Authenticate a client using biometric authentication. In case of the authentication is successful and {@link IBiometricAuthenticationCallback#onBiometricDialogSuccess(BiometricKeyData)} callback is called,
-     * you can use {@code biometricKeyEncrypted} as a parameter to {@link PowerAuthAuthentication#useBiometry} property.
+     * Authenticate a client using biometric authentication.
      *
      * @param context Context.
      * @param fragmentHelper Fragment helper for the dialog.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/KVHelper.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/KVHelper.java
@@ -34,18 +34,35 @@ import androidx.annotation.Nullable;
  */
 public class KVHelper<K> {
 
-    public @NonNull Map<K, Object> map;
+    /**
+     * Map to use in the helper.
+     */
+    public final @NonNull Map<K, Object> map;
 
+    /**
+     * Construct helper with given map.
+     * @param map Map to use in the helper.
+     */
     public KVHelper(Map<K, Object> map) {
         this.map = map != null ? map : Collections.emptyMap();
     }
 
+    /**
+     * Get a string value for given key.
+     * @param key Key to retrieve the string value.
+     * @return String for given key or null if no such item is stored in the map.
+     */
     @Nullable
     public String valueAsString(@NonNull K key) {
         final Object v = map.get(key);
         return v instanceof String ? (String) v : null;
     }
 
+    /**
+     * Get a multiline string value for given key. The returned string doesn't contain CR-LF endings.
+     * @param key Key to retrieve the string value.
+     * @return Multiline string for given key or null if no such item is stored in the map.
+     */
     @Nullable
     public String valueAsMultilineString(@NonNull K key) {
         final String s = valueAsString(key);
@@ -55,11 +72,21 @@ public class KVHelper<K> {
         return s;
     }
 
+    /**
+     * Get a boolean value for given key.
+     * @param key Key to retrieve the boolean value.
+     * @return Boolean for given key or false if no such item is stored in the map.
+     */
     public boolean valueAsBool(@NonNull K key) {
         final Object v = map.get(key);
         return v instanceof Boolean ? (Boolean) v : false;
     }
 
+    /**
+     * Get a map for given key.
+     * @param key Key to retrieve the map.
+     * @return Map for given key or false if no such item is stored.
+     */
     @SuppressWarnings("unchecked")
     @Nullable
     public Map<K, Object> valueAsMap(@NonNull K key) {
@@ -67,6 +94,11 @@ public class KVHelper<K> {
         return v instanceof Map ? (Map<K, Object>) v : null;
     }
 
+    /**
+     * Get a Date created from timestamp in seconds, stored for the given key.
+     * @param key Key to retrieve the timestamp.
+     * @return Date created from value for given key or null if no such item is stored in the map.
+     */
     @Nullable
     public Date valueAsTimestamp(@NonNull K key) {
         final Object v = map.get(key);
@@ -76,6 +108,12 @@ public class KVHelper<K> {
         return null;
     }
 
+    /**
+     * Get a Date created from string value stored for the given key.
+     * @param key Key to retrieve the date.
+     * @param format Format of date.
+     * @return Date created from value for given key, or null if no such item is stored in the map.
+     */
     @Nullable
     public Date valueAsDate(@NonNull K key, @NonNull String format) {
         final String v = valueAsString(key);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/VaultUnlockReason.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/VaultUnlockReason.java
@@ -31,8 +31,20 @@ import static io.getlime.security.powerauth.sdk.impl.VaultUnlockReason.*;
 @StringDef({ADD_BIOMETRY, FETCH_ENCRYPTION_KEY, SIGN_WITH_DEVICE_PRIVATE_KEY, RECOVERY_CODE})
 public @interface VaultUnlockReason {
 
+    /**
+     * Add biometry factor is the reason for vault unlock.
+     */
     String ADD_BIOMETRY = "ADD_BIOMETRY";
+    /**
+     * Fetch encryption key is the reason for vault unlock.
+     */
     String FETCH_ENCRYPTION_KEY = "FETCH_ENCRYPTION_KEY";
+    /**
+     * Sign with device private key is the reason for vault unlock.
+     */
     String SIGN_WITH_DEVICE_PRIVATE_KEY = "SIGN_WITH_DEVICE_PRIVATE_KEY";
+    /**
+     * Get recovery code is the reason for vault unlock.
+     */
     String RECOVERY_CODE = "RECOVERY_CODE";
 }

--- a/proj-android/build.gradle
+++ b/proj-android/build.gradle
@@ -49,4 +49,8 @@ allprojects {
         mavenCentral()
         google()
      }
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:-html', '-quiet')
+    }
 }
+


### PR DESCRIPTION
This PR adds option to disable error dialog presented from PowerAuth SDK after biometry fail. If the error dialog is disabled, then application can detect whether failure should be displayed to the user with using new `BiometricErrorInfo` enumeration, associated to `PowerAuthErrorException`.

Other changes:

- Simplified `PowerAuthSDK.authenticateWithBiometry()`. The authenticate methods now use new `IAuthenticateWithBiometryListener` that return `PowerAuthAuthentication` in success.
- Added support for missing `BIOMETRY_NOT_ENROLLED` error code (unification with iOS)

Note that documentation doesn't contain new steps for migration to 1.8. This is covered in separate PR #550 