### PR TITLE
Destroy authentication object

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricKeyData.java
@@ -18,6 +18,8 @@ package io.getlime.security.powerauth.biometry;
 
 import androidx.annotation.NonNull;
 
+import java.util.Arrays;
+
 /**
  * The {@code BiometricKeyData} class contains result from the biometric authentication in case that
  * authentication succeeded.
@@ -60,5 +62,13 @@ public class BiometricKeyData {
      */
     public boolean isNewKey() {
         return newKey;
+    }
+
+    /**
+     * Destroy potential sensitive content stored in this object.
+     */
+    public void destroy() {
+        Arrays.fill(dataToSave, (byte) 0xCD);
+        Arrays.fill(derivedData, (byte) 0xCD);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1045,6 +1045,7 @@ public class PowerAuthSDK {
             public void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData) {
                 final PowerAuthAuthentication authentication = PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometricKeyData.getDerivedData());
                 final int errorCode = persistActivationWithAuthentication(context, authentication);
+                biometricKeyData.destroy();
                 if (errorCode == PowerAuthErrorCodes.SUCCEED) {
                     callback.onBiometricDialogSuccess();
                 } else {
@@ -2360,6 +2361,8 @@ public class PowerAuthSDK {
             @Override
             public void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData) {
                 final PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithBiometry(biometricKeyData.getDerivedData());
+                // TODO: This should be moved in the next release to some global point to make sure that we always clear this object.
+                biometricKeyData.destroy();
                 listener.onBiometricDialogSuccess(authentication);
             }
 


### PR DESCRIPTION
This PR allows manual destruction of PowerAuthAuthentication object on Android. On top of that, we make sure that biometric key and other sensitive keys are also destroyed.