### PR TITLE
Use crypto 3.2 token digest calculation

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthServerApi.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthServerApi.java
@@ -272,10 +272,11 @@ public interface PowerAuthServerApi {
      * @param tokenDigest Token digest.
      * @param nonce Nonce in Base64 encoding.
      * @param timestamp Timestamp used for calculate token.
+     * @param protocolVersion Protocol version, required for server 1.5+.
      * @return {@link TokenInfo} object in case of success.
      * @throws Exception In case of failure.
      */
-    @NonNull TokenInfo validateToken(@NonNull String tokenId, @NonNull String tokenDigest, @NonNull String nonce, long timestamp) throws Exception;
+    @NonNull TokenInfo validateToken(@NonNull String tokenId, @NonNull String tokenDigest, @NonNull String nonce, long timestamp, @NonNull String protocolVersion) throws Exception;
 
     // Signatures
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/PowerAuthClientFactory.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/PowerAuthClientFactory.java
@@ -23,6 +23,7 @@ import io.getlime.security.powerauth.integration.support.PowerAuthTestConfig;
 import io.getlime.security.powerauth.integration.support.model.ServerVersion;
 import io.getlime.security.powerauth.integration.support.v10.PowerAuthClientV3_ServerV10;
 import io.getlime.security.powerauth.integration.support.v13.PowerAuthClientV3_ServerV13;
+import io.getlime.security.powerauth.integration.support.v15.PowerAuthClientV3_ServerV15;
 
 /**
  * The {@code PowerAuthClientFactory} provides client that communicate with PowerAuth Server API,
@@ -40,12 +41,13 @@ public class PowerAuthClientFactory {
      */
     public PowerAuthServerApi createApiClient(@NonNull PowerAuthTestConfig testConfig) throws Exception {
         PowerAuthServerApi api = null;
-        if (testConfig.getServerVersion().numericVersion >= ServerVersion.V1_0_0.numericVersion &&
-                testConfig.getServerVersion().numericVersion <= ServerVersion.V1_2_5.numericVersion) {
+        final int numVer = testConfig.getServerVersion().numericVersion;
+        if (numVer >= ServerVersion.V1_0_0.numericVersion && numVer < ServerVersion.V1_3_0.numericVersion) {
             api = new PowerAuthClientV3_ServerV10(testConfig.getServerApiUrl(), testConfig.getAuthorizationHeaderValue(), ServerVersion.V1_0_0, ServerVersion.V1_2_5);
-        } else if (testConfig.getServerVersion().numericVersion >= ServerVersion.V1_3_0.numericVersion &&
-                testConfig.getServerVersion().numericVersion <= ServerVersion.LATEST.numericVersion) {
-            api = new PowerAuthClientV3_ServerV13(testConfig.getServerApiUrl(), testConfig.getAuthorizationHeaderValue(), ServerVersion.V1_3_0, null);
+        } else if (numVer >= ServerVersion.V1_3_0.numericVersion && numVer < ServerVersion.V1_5_0.numericVersion) {
+            api = new PowerAuthClientV3_ServerV13(testConfig.getServerApiUrl(), testConfig.getAuthorizationHeaderValue(), ServerVersion.V1_3_0, ServerVersion.V1_4_0);
+        } else if (numVer >= ServerVersion.V1_5_0.numericVersion && numVer <= ServerVersion.LATEST.numericVersion) {
+            api = new PowerAuthClientV3_ServerV15(testConfig.getServerApiUrl(), testConfig.getAuthorizationHeaderValue(), ServerVersion.V1_5_0, null);
         }
         if (api == null) {
             throw new Exception("Missing implementation for server API, for server version " + testConfig.getServerVersion().version);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
@@ -33,13 +33,14 @@ public enum ServerVersion {
     V1_3_0("1.3", 1003000, ProtocolVersion.V3_1),
     V1_4_0("1.4", 1004000, ProtocolVersion.V3_1),
     V1_5_0("1.5", 1005000, ProtocolVersion.V3_2),
+    V1_6_0("1.6", 1006000, ProtocolVersion.V3_2),
 
     ;
 
     /**
      * Contains constant for the latest PowerAuth Server version.
      */
-    public static final ServerVersion LATEST = V1_5_0;
+    public static final ServerVersion LATEST = V1_6_0;
 
     /**
      * Server version represented as string.

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v13/PowerAuthClientV3_ServerV13.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v13/PowerAuthClientV3_ServerV13.java
@@ -328,7 +328,7 @@ public class PowerAuthClientV3_ServerV13 implements PowerAuthServerApi {
 
     @NonNull
     @Override
-    public TokenInfo validateToken(@NonNull String tokenId, @NonNull String tokenDigest, @NonNull String nonce, long timestamp) throws Exception {
+    public TokenInfo validateToken(@NonNull String tokenId, @NonNull String tokenDigest, @NonNull String nonce, long timestamp, @NonNull String protocolVersion) throws Exception {
         final ValidateTokenEndpoint.Request request = new ValidateTokenEndpoint.Request();
         request.setTokenId(tokenId);
         request.setTokenDigest(tokenDigest);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/BlockActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/BlockActivationEndpoint.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.ActivationStatus;
+
+public class BlockActivationEndpoint implements IServerApiEndpoint<BlockActivationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/block";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String externalUserId;
+        private String reason;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getExternalUserId() {
+            return externalUserId;
+        }
+
+        public void setExternalUserId(String externalUserId) {
+            this.externalUserId = externalUserId;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public void setReason(String reason) {
+            this.reason = reason;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private String activationId;
+        private ActivationStatus activationStatus;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public ActivationStatus getActivationStatus() {
+            return activationStatus;
+        }
+
+        public void setActivationStatus(ActivationStatus activationStatus) {
+            this.activationStatus = activationStatus;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CommitActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CommitActivationEndpoint.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class CommitActivationEndpoint implements IServerApiEndpoint<CommitActivationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/commit";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String activationOtp;
+        private String externalUserId;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getActivationOtp() {
+            return activationOtp;
+        }
+
+        public void setActivationOtp(String activationOtp) {
+            this.activationOtp = activationOtp;
+        }
+
+        public String getExternalUserId() {
+            return externalUserId;
+        }
+
+        public void setExternalUserId(String externalUserId) {
+            this.externalUserId = externalUserId;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private boolean activated;
+        private String activationId;
+
+        public boolean isActivated() {
+            return activated;
+        }
+
+        public void setActivated(boolean activated) {
+            this.activated = activated;
+        }
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateApplicationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateApplicationEndpoint.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.Application;
+
+public class CreateApplicationEndpoint implements IServerApiEndpoint<CreateApplicationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/application/create";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String applicationId;
+
+        public String getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationName) {
+            this.applicationId = applicationName;
+        }
+    }
+
+    // Response
+
+    public static class Response extends Application {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateApplicationVersionEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateApplicationVersionEndpoint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.ApplicationVersion;
+
+public class CreateApplicationVersionEndpoint implements IServerApiEndpoint<CreateApplicationVersionEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/application/version/create";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String applicationId;
+        private String applicationVersionId;
+
+        public String getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        public String getApplicationVersionId() {
+            return applicationVersionId;
+        }
+
+        public void setApplicationVersionId(String applicationVersionName) {
+            this.applicationVersionId = applicationVersionName;
+        }
+    }
+
+    // Response
+
+    public static class Response extends ApplicationVersion {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateNonPersonalizedOfflineSignaturePayloadEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreateNonPersonalizedOfflineSignaturePayloadEndpoint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.OfflineSignaturePayload;
+
+public class CreateNonPersonalizedOfflineSignaturePayloadEndpoint implements IServerApiEndpoint<CreateNonPersonalizedOfflineSignaturePayloadEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/signature/offline/non-personalized/create";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String applicationId;
+        private String data;
+
+        public String getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+    }
+
+    // Response
+
+    public static class Response extends OfflineSignaturePayload {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreatePersonalizedOfflineSignaturePayloadEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/CreatePersonalizedOfflineSignaturePayloadEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.OfflineSignaturePayload;
+
+public class CreatePersonalizedOfflineSignaturePayloadEndpoint implements IServerApiEndpoint<CreatePersonalizedOfflineSignaturePayloadEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/signature/offline/personalized/create";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+        private String activationId;
+        private String data;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+    }
+
+    // Response
+
+    public static class Response extends OfflineSignaturePayload {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/EmptyRequestObject.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/EmptyRequestObject.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+public class EmptyRequestObject {
+    // Empty request object
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetActivationStatusEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetActivationStatusEndpoint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
+
+public class GetActivationStatusEndpoint implements IServerApiEndpoint<GetActivationStatusEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/status";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String challenge;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getChallenge() {
+            return challenge;
+        }
+
+        public void setChallenge(String challenge) {
+            this.challenge = challenge;
+        }
+    }
+
+    // Response
+
+    public static class Response extends ActivationDetail {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetApplicationDetailEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetApplicationDetailEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.ApplicationDetail;
+
+public class GetApplicationDetailEndpoint implements IServerApiEndpoint<GetApplicationDetailEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/application/detail";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+        private String applicationId;
+        private String applicationName;
+
+        public String  getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        public String getApplicationName() {
+            return applicationName;
+        }
+
+        public void setApplicationName(String applicationName) {
+            this.applicationName = applicationName;
+        }
+    }
+
+    // Response
+
+    public static class Response extends ApplicationDetail {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetApplicationListEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetApplicationListEndpoint.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.Application;
+
+public class GetApplicationListEndpoint implements IServerApiEndpoint<GetApplicationListEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/application/list";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Empty request
+
+    // Response
+
+    public static class Response {
+        private List<Application> applications;
+
+        public List<Application> getApplications() {
+            return applications;
+        }
+
+        public void setApplications(List<Application> applications) {
+            this.applications = applications;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetRecoveryConfigEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetRecoveryConfigEndpoint.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.RecoveryConfig;
+
+public class GetRecoveryConfigEndpoint implements IServerApiEndpoint<GetRecoveryConfigEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/recovery/config/detail";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String applicationId;
+
+        public String getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationId) {
+            this.applicationId = applicationId;
+        }
+    }
+
+    // Response
+
+    public static class Response extends RecoveryConfig {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetSystemStatusEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/GetSystemStatusEndpoint.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class GetSystemStatusEndpoint implements IServerApiEndpoint<GetSystemStatusEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/status";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Empty request
+
+    // Response
+
+    public static class Response {
+
+        private String status;
+        private String applicationName;
+        private String applicationDisplayName;
+        private String applicationEnvironment;
+        private String timestamp;
+        private String version;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public String getApplicationName() {
+            return applicationName;
+        }
+
+        public void setApplicationName(String applicationName) {
+            this.applicationName = applicationName;
+        }
+
+        public String getApplicationDisplayName() {
+            return applicationDisplayName;
+        }
+
+        public void setApplicationDisplayName(String applicationDisplayName) {
+            this.applicationDisplayName = applicationDisplayName;
+        }
+
+        public String getApplicationEnvironment() {
+            return applicationEnvironment;
+        }
+
+        public void setApplicationEnvironment(String applicationEnvironment) {
+            this.applicationEnvironment = applicationEnvironment;
+        }
+
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(String timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/InitActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/InitActivationEndpoint.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.Activation;
+import io.getlime.security.powerauth.integration.support.model.ActivationOtpValidation;
+
+public class InitActivationEndpoint implements IServerApiEndpoint<InitActivationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/init";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationOtp;
+        private ActivationOtpValidation activationOtpValidation;
+        private String applicationId;
+        private long maxFailureCount;
+        private String userId;
+
+        public String getActivationOtp() {
+            return activationOtp;
+        }
+
+        public void setActivationOtp(String activationOtp) {
+            this.activationOtp = activationOtp;
+        }
+
+        public ActivationOtpValidation getActivationOtpValidation() {
+            return activationOtpValidation;
+        }
+
+        public void setActivationOtpValidation(ActivationOtpValidation activationOtpValidation) {
+            this.activationOtpValidation = activationOtpValidation;
+        }
+
+        public String getApplicationId() {
+            return applicationId;
+        }
+
+        public void setApplicationId(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        public long getMaxFailureCount() {
+            return maxFailureCount;
+        }
+
+        public void setMaxFailureCount(long maxFailureCount) {
+            this.maxFailureCount = maxFailureCount;
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+
+    // Response
+
+    public static class Response extends Activation {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/RemoveActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/RemoveActivationEndpoint.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class RemoveActivationEndpoint implements IServerApiEndpoint<RemoveActivationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/remove";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String externalUserId;
+        private boolean revokeRecoveryCodes;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getExternalUserId() {
+            return externalUserId;
+        }
+
+        public void setExternalUserId(String externalUserId) {
+            this.externalUserId = externalUserId;
+        }
+
+        public boolean isRevokeRecoveryCodes() {
+            return revokeRecoveryCodes;
+        }
+
+        public void setRevokeRecoveryCodes(boolean revokeRecoveryCodes) {
+            this.revokeRecoveryCodes = revokeRecoveryCodes;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private String activationId;
+        private boolean removed;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public boolean isRemoved() {
+            return removed;
+        }
+
+        public void setRemoved(boolean removed) {
+            this.removed = removed;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/SetApplicationVersionSupportedEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/SetApplicationVersionSupportedEndpoint.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class SetApplicationVersionSupportedEndpoint implements IServerApiEndpoint<SetApplicationVersionSupportedEndpoint.Response> {
+
+    private final boolean supported;
+
+    public SetApplicationVersionSupportedEndpoint(boolean supported) {
+        this.supported = supported;
+    }
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return supported ? "/rest/v3/application/version/support" : "/rest/v3/application/version/unsupport";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String applicationVersionId;
+
+        public String getApplicationVersionId() {
+            return applicationVersionId;
+        }
+
+        public void setApplicationVersionId(String applicationVersionId) {
+            this.applicationVersionId = applicationVersionId;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private String applicationVersionId;
+        private boolean supported;
+
+        public String getApplicationVersionId() {
+            return applicationVersionId;
+        }
+
+        public void setApplicationVersionId(String applicationVersionId) {
+            this.applicationVersionId = applicationVersionId;
+        }
+
+        public boolean isSupported() {
+            return supported;
+        }
+
+        public void setSupported(boolean supported) {
+            this.supported = supported;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UnblockActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UnblockActivationEndpoint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.ActivationStatus;
+
+public class UnblockActivationEndpoint implements IServerApiEndpoint<UnblockActivationEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/unblock";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(UnblockActivationEndpoint.Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String externalUserId;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getExternalUserId() {
+            return externalUserId;
+        }
+
+        public void setExternalUserId(String externalUserId) {
+            this.externalUserId = externalUserId;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private String activationId;
+        private ActivationStatus activationStatus;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public ActivationStatus getActivationStatus() {
+            return activationStatus;
+        }
+
+        public void setActivationStatus(ActivationStatus activationStatus) {
+            this.activationStatus = activationStatus;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UpdateActivationOtpEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UpdateActivationOtpEndpoint.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class UpdateActivationOtpEndpoint implements IServerApiEndpoint<UpdateActivationOtpEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/activation/otp/update";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String activationId;
+        private String activationOtp;
+        private String externalUserId;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getActivationOtp() {
+            return activationOtp;
+        }
+
+        public void setActivationOtp(String activationOtp) {
+            this.activationOtp = activationOtp;
+        }
+
+        public String getExternalUserId() {
+            return externalUserId;
+        }
+
+        public void setExternalUserId(String externalUserId) {
+            this.externalUserId = externalUserId;
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private String activationId;
+        private boolean updated;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public boolean isUpdated() {
+            return updated;
+        }
+
+        public void setUpdated(boolean updated) {
+            this.updated = updated;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UpdateRecoveryConfigEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/UpdateRecoveryConfigEndpoint.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.RecoveryConfig;
+
+public class UpdateRecoveryConfigEndpoint implements IServerApiEndpoint<UpdateRecoveryConfigEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/recovery/config/update";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request extends RecoveryConfig {
+
+        /**
+         * Create request from given recovery config.
+         * @param config Recovery config.
+         */
+        public Request(@NonNull RecoveryConfig config) {
+            setApplicationId(config.getApplicationId());
+            setActivationRecoveryEnabled(config.isActivationRecoveryEnabled());
+            setRecoveryPostcardEnabled(config.isRecoveryPostcardEnabled());
+            setAllowMultipleRecoveryCodes(config.getAllowMultipleRecoveryCodes());
+            setRemotePostcardPublicKey(config.getRemotePostcardPublicKey());
+        }
+    }
+
+    // Response
+
+    public static class Response {
+
+        private boolean updated;
+
+        public boolean isUpdated() {
+            return updated;
+        }
+
+        public void setUpdated(boolean updated) {
+            this.updated = updated;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/ValidateTokenEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/ValidateTokenEndpoint.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.TokenInfo;
+
+public class ValidateTokenEndpoint implements IServerApiEndpoint<ValidateTokenEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/token/validate";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    // Request
+
+    public static class Request {
+
+        private String tokenId;
+        private String tokenDigest;
+        private String nonce;
+        private long timestamp;
+        private String protocolVersion;
+
+        public String getTokenId() {
+            return tokenId;
+        }
+
+        public void setTokenId(String tokenId) {
+            this.tokenId = tokenId;
+        }
+
+        public String getTokenDigest() {
+            return tokenDigest;
+        }
+
+        public void setTokenDigest(String tokenDigest) {
+            this.tokenDigest = tokenDigest;
+        }
+
+        public String getNonce() {
+            return nonce;
+        }
+
+        public void setNonce(String nonce) {
+            this.nonce = nonce;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public String getProtocolVersion() {
+            return protocolVersion;
+        }
+
+        public void setProtocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+        }
+    }
+
+    // Response
+
+    public static class Response extends TokenInfo {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyEcdsaSignatureEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyEcdsaSignatureEndpoint.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+
+public class VerifyEcdsaSignatureEndpoint implements IServerApiEndpoint<VerifyEcdsaSignatureEndpoint.Response> {
+
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/signature/ecdsa/verify";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    public static class Request {
+
+        private String activationId;
+        private String data;
+        private String signature;
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public String getSignature() {
+            return signature;
+        }
+
+        public void setSignature(String signature) {
+            this.signature = signature;
+        }
+    }
+
+    public static class Response {
+
+        private boolean signatureValid;
+
+        public boolean isSignatureValid() {
+            return signatureValid;
+        }
+
+        public void setSignatureValid(boolean signatureValid) {
+            this.signatureValid = signatureValid;
+        }
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyOfflineSignatureEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyOfflineSignatureEndpoint.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.SignatureData;
+import io.getlime.security.powerauth.integration.support.model.SignatureInfo;
+
+public class VerifyOfflineSignatureEndpoint implements IServerApiEndpoint<VerifyOfflineSignatureEndpoint.Response> {
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/signature/offline/verify";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    public static class Request {
+
+        private String activationId;
+        private String data;
+        private String signature;
+        private boolean allowBiometry;
+
+        public Request(@NonNull SignatureData sd) {
+            activationId = sd.getActivationId();
+            data = sd.getData();
+            signature = sd.getSignature();
+            allowBiometry = sd.getAllowBiometry() != null ? sd.getAllowBiometry() : false;
+        }
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public String getSignature() {
+            return signature;
+        }
+
+        public void setSignature(String signature) {
+            this.signature = signature;
+        }
+
+        public boolean isAllowBiometry() {
+            return allowBiometry;
+        }
+
+        public void setAllowBiometry(boolean allowBiometry) {
+            this.allowBiometry = allowBiometry;
+        }
+    }
+
+    public static class Response extends SignatureInfo {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyOnlineSignatureEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v15/endpoints/VerifyOnlineSignatureEndpoint.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support.v15.endpoints;
+
+import com.google.gson.reflect.TypeToken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.integration.support.client.IServerApiEndpoint;
+import io.getlime.security.powerauth.integration.support.model.SignatureData;
+import io.getlime.security.powerauth.integration.support.model.SignatureInfo;
+import io.getlime.security.powerauth.integration.support.model.SignatureType;
+
+public class VerifyOnlineSignatureEndpoint implements IServerApiEndpoint<VerifyOnlineSignatureEndpoint.Response> {
+    @NonNull
+    @Override
+    public String getRelativePath() {
+        return "/rest/v3/signature/verify";
+    }
+
+    @Nullable
+    @Override
+    public TypeToken<Response> getResponseType() {
+        return TypeToken.get(Response.class);
+    }
+
+    public static class Request {
+
+        private String activationId;
+        private String applicationKey;
+        private String data;
+        private String signature;
+        private SignatureType signatureType;
+        private String signatureVersion;
+        private Long forcedSignatureVersion;
+
+        public Request(@NonNull SignatureData sd) {
+            activationId = sd.getActivationId();
+            applicationKey = sd.getApplicationKey();
+            data = sd.getData();
+            signature = sd.getSignature();
+            signatureType = sd.getSignatureType();
+            signatureVersion = sd.getSignatureVersion();
+            forcedSignatureVersion = sd.getForcedSignatureVersion();
+        }
+
+        public String getActivationId() {
+            return activationId;
+        }
+
+        public void setActivationId(String activationId) {
+            this.activationId = activationId;
+        }
+
+        public String getApplicationKey() {
+            return applicationKey;
+        }
+
+        public void setApplicationKey(String applicationKey) {
+            this.applicationKey = applicationKey;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public String getSignature() {
+            return signature;
+        }
+
+        public void setSignature(String signature) {
+            this.signature = signature;
+        }
+
+        public SignatureType getSignatureType() {
+            return signatureType;
+        }
+
+        public void setSignatureType(SignatureType signatureType) {
+            this.signatureType = signatureType;
+        }
+
+        public String getSignatureVersion() {
+            return signatureVersion;
+        }
+
+        public void setSignatureVersion(String signatureVersion) {
+            this.signatureVersion = signatureVersion;
+        }
+
+        public Long getForcedSignatureVersion() {
+            return forcedSignatureVersion;
+        }
+
+        public void setForcedSignatureVersion(Long forcedSignatureVersion) {
+            this.forcedSignatureVersion = forcedSignatureVersion;
+        }
+    }
+
+    public static class Response extends SignatureInfo {
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TokenStoreTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TokenStoreTest.java
@@ -417,8 +417,9 @@ public class TokenStoreTest {
         long timestamp = Long.parseLong(Objects.requireNonNull(headerComponents.get("timestamp")));
         String nonce = Objects.requireNonNull(headerComponents.get("nonce"));
         String digest = Objects.requireNonNull(headerComponents.get("token_digest"));
+        String version = Objects.requireNonNull(headerComponents.get("version"));
 
-        TokenInfo tokenInfo = testHelper.getServerApi().validateToken(tokenId, digest, nonce, timestamp);
+        TokenInfo tokenInfo = testHelper.getServerApi().validateToken(tokenId, digest, nonce, timestamp, version);
         assertNotNull(tokenInfo);
         assertTrue(tokenInfo.isTokenValid());
         assertEquals(expectedSignatureType, tokenInfo.getSignatureType());

--- a/proj-xcode/PowerAuth2/PowerAuthToken.m
+++ b/proj-xcode/PowerAuth2/PowerAuthToken.m
@@ -99,6 +99,7 @@
     tokenIdentifier = _tokenData.identifier;
 
     // Prepare data for HMAC
+    NSString * protocolVersion = @"3.2";
     NSNumber * currentTimeMs = @((int64_t)([timeService currentTime] * 1000.0));
     NSString * currentTimeString = [currentTimeMs stringValue];
     NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
@@ -110,6 +111,9 @@
     NSMutableData * data = [nonce mutableCopy];
     [data appendBytes:"&" length:1];
     [data appendData: currentTimeData];
+    [data appendBytes:"&" length:1];
+    [data appendData:[protocolVersion dataUsingEncoding:NSASCIIStringEncoding]];
+    
     // Calculate digest...
     NSData * digest = [PowerAuthCoreCryptoUtils hmacSha256:data key:tokenSecret];
     NSString * digestBase64 = [digest base64EncodedStringWithOptions:0];
@@ -120,12 +124,12 @@
         return nil;
     }
     NSString * value = [NSString stringWithFormat:
-                        @"PowerAuth version=\"3.2\""
+                        @"PowerAuth version=\"%@\""
                         @", token_id=\"%@\""
                         @", token_digest=\"%@\""
                         @", nonce=\"%@\""
                         @", timestamp=\"%@\"",
-                        tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
+                        protocolVersion, tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
     return [PowerAuthAuthorizationHttpHeader tokenHeaderWithValue:value];
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
@@ -780,6 +780,7 @@ static NSString * PA_Ver = @"3.2";
     validationRequest.tokenDigest       = parsedHeader[@"token_digest"];
     validationRequest.nonce             = parsedHeader[@"nonce"];
     validationRequest.timestamp         = parsedHeader[@"timestamp"];
+    validationRequest.protocolVersion   = parsedHeader[@"version"];
     PATSTokenValidationResponse * validationResponse = [_testServerApi validateTokenRequest:validationRequest];
     XCTAssertTrue(validationResponse.tokenValid == expectedResult);
     if (expectedResult) {

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerAPI.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerAPI.m
@@ -54,6 +54,7 @@
         return NO;
     }
     _testServerConfig.serverApiVersion = [_rest applyServerVersion:systemStatus.version];
+    _testServerConfig.serverMaxProtovolVersion = PATSProtoVer(_testServerConfig.serverApiVersion);
     _serverVersion = _testServerConfig.serverApiVersion;
     
     NSArray<PATSApplication*>* applicationList = [self getApplicationList];
@@ -346,7 +347,12 @@ static PATSActivationStatusEnum _String_to_ActivationStatusEnum(NSString * str)
 - (PATSTokenValidationResponse*) validateTokenRequest:(PATSTokenValidationRequest*)request
 {
     [self checkForValidConnection];
-    NSArray * params = @[ request.tokenIdentifier, request.tokenDigest, request.nonce, request.timestamp ];
+    NSArray * params;
+    if (_testServerConfig.serverMaxProtovolVersion == PATS_P32) {
+        params = @[ request.tokenIdentifier, request.tokenDigest, request.nonce, request.timestamp, request.protocolVersion];
+    } else {
+        params = @[ request.tokenIdentifier, request.tokenDigest, request.nonce, request.timestamp];
+    }
     return [_rest request:@"TokenValidate" params:params];
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(int, PowerAuthTestServerVersion) {
     PATS_V1_2_5 = 10205,    // V3.1 crypto + Activation OTP
     PATS_V1_3   = 10300,    // V3.1 crypto + Activation OTP, applicationId as String
     PATS_V1_4   = 10400,    // V3.1 crypto + Activation OTP, applicationId as String
-    PATS_V1_5   = 10500,    // V3.1 crypto + Activation OTP, applicationId as String, userInfo
+    PATS_V1_5   = 10500,    // V3.2 crypto + Activation OTP, applicationId as String, userInfo
 };
 
 /**
@@ -37,6 +37,7 @@ typedef NS_ENUM(int, PowerAuthProtocolVersion) {
     PATS_P2,        // V2 crypto
     PATS_P3,        // V3 crypto
     PATS_P31,       // V3.1 crypto
+    PATS_P32,       // V3.2 crypto
 };
 
 /**
@@ -71,6 +72,10 @@ extern PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVe
  "V2" is the default value. Loaded after the connection to server is established.
  */
 @property (nonatomic, assign) PowerAuthTestServerVersion serverApiVersion;
+/**
+ Maximum supported protocol version.
+ */
+@property (nonatomic, assign) PowerAuthProtocolVersion serverMaxProtovolVersion;
 /**
  A name for application, which will be used on the PA2 server.
  Default value is @"AutomaticTest-IOS"

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.m
@@ -53,6 +53,9 @@
 
 PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVer)
 {
+    if (serverVer >= PATS_V1_5) {
+        return PATS_P32;
+    }
     return PATS_P31;
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.h
@@ -177,6 +177,7 @@ extern NSString * PATSActivationOtpValidationEnumToString(PATSActivationOtpValid
 
 @interface PATSTokenValidationRequest : NSObject
 
+@property (nonatomic, strong) NSString * protocolVersion;
 @property (nonatomic, strong) NSString * tokenIdentifier;
 @property (nonatomic, strong) NSString * tokenDigest;
 @property (nonatomic, strong) NSString * nonce;

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/TokenValidate_v10.json
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/TokenValidate_v10.json
@@ -1,0 +1,19 @@
+{
+    "path": "/rest/v3/token/validate",
+    "parameters": [
+        "tokenId",
+        "tokenDigest",
+        "nonce",
+        "timestamp"
+    ],
+    "response": {
+        "class": "PATSTokenValidationResponse",
+        "properties": {
+            "tokenValid":       { "class" : "bool" },
+            "activationId":     { "class" : "string" },
+            "userId":           { "class" : "string" },
+            "applicationId":    { "class" : "string" },
+            "signatureType":    { "class" : "string" }
+        }
+    }
+}

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/TokenValidate_v15.json
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/TokenValidate_v15.json
@@ -4,7 +4,8 @@
         "tokenId",
         "tokenDigest",
         "nonce",
-        "timestamp"
+        "timestamp",
+        "protocolVersion"
     ],
     "response": {
         "class": "PATSTokenValidationResponse",

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/mappings.json
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/mappings.json
@@ -6,6 +6,7 @@
         "1.3" : "v13",
         "1.4" : "v13",
         "1.5" : "v15",
+        "1.6" : "v15",
         
         "*"   : "v15"
     },
@@ -16,7 +17,8 @@
             "GetApplicationDetail":         "GetApplicationDetail_v10",
             "CreateApplicationVersion":     "CreateApplicationVersion_v10",
             "SupportApplicationVersion":    "SupportApplicationVersion_v10",
-            "UnsupportApplicationVersion":  "UnsupportApplicationVersion_v10"
+            "UnsupportApplicationVersion":  "UnsupportApplicationVersion_v10",
+            "TokenValidate":                "TokenValidate_v10"
         },
         "v13": {
             "GetApplicationList":           "GetApplicationList_v13",
@@ -24,11 +26,13 @@
             "GetApplicationDetail":         "GetApplicationDetail_v13",
             "CreateApplicationVersion":     "CreateApplicationVersion_v13",
             "SupportApplicationVersion":    "SupportApplicationVersion_v13",
-            "UnsupportApplicationVersion":  "UnsupportApplicationVersion_v13"
+            "UnsupportApplicationVersion":  "UnsupportApplicationVersion_v13",
+            "TokenValidate":                "TokenValidate_v10"
         },
         "v15": { "#base": "v13",
             "GetApplicationDetail":         "GetApplicationDetail_v15",
-            "CreateApplicationVersion":     "CreateApplicationVersion_v15"
+            "CreateApplicationVersion":     "CreateApplicationVersion_v15",
+            "TokenValidate":                "TokenValidate_v15"
         }
     }   
 }

--- a/src/PowerAuth/jni/TokenCalculatorJNI.cpp
+++ b/src/PowerAuth/jni/TokenCalculatorJNI.cpp
@@ -57,12 +57,15 @@ CC7_JNI_METHOD_PARAMS(jstring, calculateTokenValue, jobject privateData, jlong t
     cc7::ByteArray nonce = crypto::GetRandomData(16);
 
     // Construct data for HMAC and calculate that digest.
+    auto protocol_version = Version_GetMaxSupportedHttpProtocolVersion(Version_Latest);
     cc7::ByteArray data;
-    data.reserve(16 + 1 + timestamp_string.length());
+    data.reserve(16 + 1 + timestamp_string.length() + 1 + protocol_version.length());
 
     data.assign(nonce);
     data.append(cc7::MakeRange(protocol::AMP));
     data.append(cc7::MakeRange(timestamp_string));
+    data.append(cc7::MakeRange(protocol::AMP));
+    data.append(cc7::MakeRange(protocol_version));
     auto digest = crypto::HMAC_SHA256(data, cppTokenSecret, 0);
     if (digest.size() == 0) {
         CC7_ASSERT(false, "Unable to calculate HMAC for data.");
@@ -77,7 +80,7 @@ CC7_JNI_METHOD_PARAMS(jstring, calculateTokenValue, jobject privateData, jlong t
     result.reserve(cppTokenIdentifier.length() + digestBase64.length() + nonceBase64.length() + timestamp_string.length() + 80);
 
     result.assign("PowerAuth version=\"");
-    result.append(Version_GetMaxSupportedHttpProtocolVersion(Version_Latest));
+    result.append(protocol_version);
     result.append("\", token_id=\"");
     result.append(cppTokenIdentifier);
     result.append("\", token_digest=\"");


### PR DESCRIPTION
This PR updates token digest calculation to be compatible with servers running on protocol V3.2. The change itself is quite simple, the rest of the pull request contains test framework updates.