### PR TITLE
Apple: Import PowerAuthCore as module in private header

### DIFF
--- a/proj-xcode/PowerAuth2/private/PA2TimeSynchronizationService.h
+++ b/proj-xcode/PowerAuth2/private/PA2TimeSynchronizationService.h
@@ -15,9 +15,10 @@
  */
 
 #import <PowerAuth2/PowerAuthTimeSynchronizationService.h>
-#import <PowerAuthCore/PowerAuthCoreTimeService.h>
 
 #import "PA2GetSystemStatusTask.h"
+
+@import PowerAuthCore;
 
 /// The `PA2TimeSynchronizationService` class provides functionality to synchronize time with the server.
 /// The class implements both `PowerAuthTimeSynchronizationService` and `PowerAuthCoreTimeService` protocols.


### PR DESCRIPTION
This change is important for CocoaPods integration. Import of particular header doesn't work in CocoaPods, so we have to use module import.