### PR TITLE
Xcode 15.x warnings

### DIFF
--- a/proj-xcode/PowerAuth2/PowerAuthLog.h
+++ b/proj-xcode/PowerAuth2/PowerAuthLog.h
@@ -33,7 +33,7 @@
 
     // Implementations
 
-    PA2_EXTERN_C void PowerAuthLogImpl(NSString * format, ...);
+    PA2_EXTERN_C void PowerAuthLogImpl(NSString * _Nonnull format, ...);
 
     // Macros
 
@@ -79,7 +79,7 @@ PA2_EXTERN_C BOOL PowerAuthLogIsVerbose(void);
  is used internally in the PowerAuth SDK. This kind of warnings are always printed to the DEBUG
  console and cannot be supressed by configuration.
  */
-PA2_EXTERN_C void PowerAuthCriticalWarning(NSString * format, ...);
+PA2_EXTERN_C void PowerAuthCriticalWarning(NSString * _Nonnull format, ...);
 
 /**
  Protocol that represents a delegate that can tap into the library logs and use them for example

--- a/scripts/config-apple.sh
+++ b/scripts/config-apple.sh
@@ -1,5 +1,5 @@
 # Platform CPU architectures
-ARCH_IOS="arm64 arm64e"
+ARCH_IOS="arm64"
 ARCH_IOS_SIM="x86_64 arm64"
 ARCH_CATALYST="x86_64"
 ARCH_TVOS="arm64"


### PR DESCRIPTION
This PR fixes warnings introduced in Xcode 15.3 and removes support for `arm64e` architecture