### PR TITLE
Store biometry key for each PowerAuthSDK instance

### DIFF
--- a/docs/Migration-from-1.6-to-1.7.md
+++ b/docs/Migration-from-1.6-to-1.7.md
@@ -214,3 +214,12 @@ The behavior of `PowerAuthSDK.authenticateUsingBiometry()` has been slightly cha
 ### tvOS
 
 The `PowerAuthSDK.authenticateUsingBiometry()` function is no longer available on tvOS platform.
+
+## Changes in 1.7.10+
+
+### Android
+
+- The shared biometry-related encryption key is no longer supported in `PowerAuthSDK`. If an activation is already using the shared key, then it's in use until the activation or the biometry factor is removed. As part of this change, the following methods are now deprecated:
+  - Method `PowerAuthSDK.removeActivationLocal(Context, boolean)` is now deprecated. Use `removeActivationLocal(Context)` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.getKeychainBiometryDefaultKey()` is now deprecated. Use `getKeychainKeyBiometry()` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.Builder.keychainBiometryDefaultKey(String)` is now deprecated. Use `keychainKeyBiometry(String)` as a replacement.

--- a/docs/Migration-from-1.7-to-1.8.md
+++ b/docs/Migration-from-1.7-to-1.8.md
@@ -298,3 +298,13 @@ You can watch the following related issues:
 - [wultra/powerauth-mobile-sdk#551](https://github.com/wultra/powerauth-mobile-sdk/issues/551)
 - [wultra/powerauth-mobile-watch-sdk#7](https://github.com/wultra/powerauth-mobile-watch-sdk/issues/7)
 - [wultra/powerauth-mobile-extensions-sdk#7](https://github.com/wultra/powerauth-mobile-extensions-sdk/issues/7)
+
+## Changes in 1.8.3+
+
+### Android
+
+- The shared biometry-related encryption key is no longer supported in `PowerAuthSDK`. If an activation is already using the shared key, then it's in use until the activation or the biometry factor is removed. As part of this change, the following methods are now deprecated:
+  - Method `PowerAuthSDK.removeActivationLocal(Context, boolean)` is now deprecated. Use `removeActivationLocal(Context)` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.getKeychainBiometryDefaultKey()` is now deprecated. Use `getKeychainKeyBiometry()` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.Builder.keychainBiometryDefaultKey(String)` is now deprecated. Use `keychainKeyBiometry(String)` as a replacement.
+  

--- a/docs/Migration-from-1.8-to-1.9.md
+++ b/docs/Migration-from-1.8-to-1.9.md
@@ -19,6 +19,11 @@ PowerAuth Mobile SDK in version `1.9.0` provides the following improvements:
   - Synchronous method `getEciesEncryptorForApplicationScope()` is replaced with asynchronous variant that guarantees the temporary encryption key is prepared.
   - Synchronous method `getEciesEncryptorForActivationScope()` is replaced with asynchronous variant that guarantees the temporary encryption key is prepared.
 
+- The shared biometry-related encryption key is no longer supported in `PowerAuthSDK`. If an activation is already using the shared key, then it's in use until the activation or the biometry factor is removed. As part of this change, the following methods are now deprecated:
+  - Method `PowerAuthSDK.removeActivationLocal(Context, boolean)` is now deprecated. Use `removeActivationLocal(Context)` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.getKeychainBiometryDefaultKey()` is now deprecated. Use `getKeychainKeyBiometry()` as a replacement.
+  - Method `PowerAuthKeychainConfiguration.Builder.keychainBiometryDefaultKey(String)` is now deprecated. Use `keychainKeyBiometry(String)` as a replacement.
+  
 - Removed all interfaces deprecated in release `1.8.x`
 
 ### Other changes

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
@@ -208,7 +208,7 @@ public class PowerAuthTestHelper {
                 if (sdk.hasValidActivation()) {
                     Logger.e("Shared PowerAuthSDK has a valid activation at test initialization.");
                 }
-                sdk.removeActivationLocal(context, true);
+                sdk.removeActivationLocal(context);
             } else {
                 if (!sdk.hasValidActivation()) {
                     Logger.e("Shared PowerAuthSDK doesn't have a valid activation at test initialization.");
@@ -449,7 +449,7 @@ public class PowerAuthTestHelper {
                 .keychainConfiguration(getSharedPowerAuthKeychainConfiguration())
                 .build(getContext());
         if (resetActivation && sdk.hasValidActivation()) {
-            sdk.removeActivationLocal(getContext(), true);
+            sdk.removeActivationLocal(getContext());
         }
         return sdk;
     }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
@@ -188,17 +188,15 @@ public class ActivationHelper {
             invalidAuthentication = null;
             createActivationResult = null;
         }
-        removeActivationLocal(true);
+        removeActivationLocal();
     }
 
     /**
      * Remove activation locally.
-     *
-     * @param removeSharedBiometryKey If true, then also remove a shared biometry key.
      */
-    public void removeActivationLocal(boolean removeSharedBiometryKey) {
+    public void removeActivationLocal() {
         if (powerAuthSDK.hasValidActivation()) {
-            powerAuthSDK.removeActivationLocal(testHelper.getContext(), removeSharedBiometryKey);
+            powerAuthSDK.removeActivationLocal(testHelper.getContext());
         }
     }
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/StandardActivationTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/StandardActivationTest.java
@@ -254,7 +254,7 @@ public class StandardActivationTest {
     public void testRemoveActivationLocal() throws Exception {
         activationHelper.createStandardActivation(true, null);
         // Remove activation
-        powerAuthSDK.removeActivationLocal(testHelper.getContext(), true);
+        powerAuthSDK.removeActivationLocal(testHelper.getContext());
         // Back to Initial expectations
         assertFalse(powerAuthSDK.hasValidActivation());
         assertFalse(powerAuthSDK.hasPendingActivation());

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfigurationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfigurationBuilderTest.java
@@ -35,7 +35,7 @@ public class PowerAuthKeychainConfigurationBuilderTest {
         assertEquals(PowerAuthKeychainConfiguration.KEYCHAIN_ID_BIOMETRY, configuration.getKeychainBiometryId());
         assertEquals(PowerAuthKeychainConfiguration.KEYCHAIN_ID_STATUS, configuration.getKeychainStatusId());
         assertEquals(PowerAuthKeychainConfiguration.KEYCHAIN_ID_TOKEN_STORE, configuration.getKeychainTokenStoreId());
-        assertEquals(PowerAuthKeychainConfiguration.KEYCHAIN_KEY_BIOMETRY_DEFAULT, configuration.getKeychainBiometryDefaultKey());
+        assertNull(configuration.getKeychainKeyBiometry());
         assertEquals(KeychainProtection.NONE, configuration.getMinimalRequiredKeychainProtection());
         assertFalse(configuration.isConfirmBiometricAuthentication());
         assertTrue(configuration.isLinkBiometricItemsToCurrentSet());
@@ -50,14 +50,14 @@ public class PowerAuthKeychainConfigurationBuilderTest {
                 .keychainBiometryId("keychain.biometry")
                 .keychainStatusId("keychain.status")
                 .keychainTokenStoreId("keychain.tokens")
-                .keychainBiometryDefaultKey("biometryKey")
+                .keychainKeyBiometry("biometryKey")
                 .minimalRequiredKeychainProtection(KeychainProtection.HARDWARE)
                 .authenticateOnBiometricKeySetup(false)
                 .build();
         assertEquals("keychain.biometry", configuration.getKeychainBiometryId());
         assertEquals("keychain.status", configuration.getKeychainStatusId());
         assertEquals("keychain.tokens", configuration.getKeychainTokenStoreId());
-        assertEquals("biometryKey", configuration.getKeychainBiometryDefaultKey());
+        assertEquals("biometryKey", configuration.getKeychainKeyBiometry());
         assertEquals(KeychainProtection.HARDWARE, configuration.getMinimalRequiredKeychainProtection());
         assertTrue(configuration.isConfirmBiometricAuthentication());
         assertFalse(configuration.isLinkBiometricItemsToCurrentSet());

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -135,7 +135,7 @@ public class BiometricAuthentication {
                 @Override
                 public void onBiometricKeyUnavailable() {
                     // Remove the default key, because the biometric key is no longer available.
-                    device.getBiometricKeystore().removeBiometricKeyEncryptor();
+                    device.getBiometricKeystore().removeBiometricKeyEncryptor(request.getKeystoreAlias());
                 }
             });
             final IBiometricKeyEncryptorProvider biometricKeyEncryptorProvider = new DefaultBiometricKeyEncryptorProvider(request, getBiometricKeystore());
@@ -170,7 +170,7 @@ public class BiometricAuthentication {
             }
             // Failed to use biometric authentication. At first, we should cleanup the possible stored
             // biometric key.
-            device.getBiometricKeystore().removeBiometricKeyEncryptor();
+            device.getBiometricKeystore().removeBiometricKeyEncryptor(request.getKeystoreAlias());
 
             // Now show the error dialog, and report the exception later.
             if (exception == null) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -38,6 +38,7 @@ public class BiometricAuthenticationRequest {
     private final @NonNull CharSequence title;
     private final @Nullable CharSequence subtitle;
     private final @NonNull CharSequence description;
+    private final @NonNull String keystoreAlias;
     private final boolean forceGenerateNewKey;
     private final boolean invalidateByBiometricEnrollment;
     private final boolean userConfirmationRequired;
@@ -52,6 +53,7 @@ public class BiometricAuthenticationRequest {
             @NonNull CharSequence description,
             @Nullable Fragment fragment,
             @Nullable FragmentActivity fragmentActivity,
+            @NonNull String keystoreAlias,
             boolean forceGenerateNewKey,
             boolean invalidateByBiometricEnrollment,
             boolean userConfirmationRequired,
@@ -64,6 +66,7 @@ public class BiometricAuthenticationRequest {
         this.description = description;
         this.fragment = fragment;
         this.fragmentActivity = fragmentActivity;
+        this.keystoreAlias = keystoreAlias;
         this.forceGenerateNewKey = forceGenerateNewKey;
         this.invalidateByBiometricEnrollment = invalidateByBiometricEnrollment;
         this.userConfirmationRequired = userConfirmationRequired;
@@ -106,6 +109,14 @@ public class BiometricAuthenticationRequest {
      */
     public @Nullable FragmentActivity getFragmentActivity() {
         return fragmentActivity;
+    }
+
+    /**
+     * @return Alias to Android Keystore for the existing, or the new created key.
+     */
+    @NonNull
+    public String getKeystoreAlias() {
+        return keystoreAlias;
     }
 
     /**
@@ -173,6 +184,7 @@ public class BiometricAuthenticationRequest {
         private Fragment fragment;
         private FragmentActivity fragmentActivity;
 
+        private String keystoreAlias;
         private boolean forceGenerateNewKey = false;
         private boolean invalidateByBiometricEnrollment = true;
         private boolean userConfirmationRequired = false;
@@ -200,6 +212,9 @@ public class BiometricAuthenticationRequest {
             if (TextUtils.isEmpty(title) || TextUtils.isEmpty(description)) {
                 throw new IllegalArgumentException("Title and description is required.");
             }
+            if (keystoreAlias == null) {
+                throw new IllegalArgumentException("KeyStore alias is required.");
+            }
             if (rawKeyData == null) {
                 throw new IllegalArgumentException("RawKeyData is required.");
             }
@@ -218,6 +233,7 @@ public class BiometricAuthenticationRequest {
                     description,
                     fragment,
                     fragmentActivity,
+                    keystoreAlias,
                     forceGenerateNewKey,
                     invalidateByBiometricEnrollment,
                     userConfirmationRequired,
@@ -314,6 +330,16 @@ public class BiometricAuthenticationRequest {
          */
         public Builder setFragmentActivity(@NonNull FragmentActivity fragmentActivity) {
             this.fragmentActivity = fragmentActivity;
+            return this;
+        }
+
+        /**
+         * Required: Set alias for a new or existing key stored in the Android Keystore.
+         * @param keystoreAlias Alias to key to create or access.
+         * @return This value will never be {@code null}.
+         */
+        public Builder setKeystoreAlias(@NonNull String keystoreAlias) {
+            this.keystoreAlias = keystoreAlias;
             return this;
         }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
@@ -16,6 +16,7 @@
 
 package io.getlime.security.powerauth.biometry;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
@@ -38,7 +39,7 @@ public interface IBiometricKeystore {
      * @return {@code true} in case a key for biometric key encryptor is present, false otherwise.
      *         Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
      */
-    boolean containsBiometricKeyEncryptor();
+    boolean containsBiometricKeyEncryptor(@NonNull String keyId);
 
     /**
      * Generate a new biometry related Keystore key and return object that provide KEK encryption and decryption.
@@ -52,17 +53,24 @@ public interface IBiometricKeystore {
      * @return New generated {@link IBiometricKeyEncryptor} key or {@code null} in case of failure.
      */
     @Nullable
-    IBiometricKeyEncryptor createBiometricKeyEncryptor(boolean invalidateByBiometricEnrollment, boolean useSymmetricKey);
+    IBiometricKeyEncryptor createBiometricKeyEncryptor(@NonNull String keyId, boolean invalidateByBiometricEnrollment, boolean useSymmetricKey);
 
     /**
      * Removes an encryption key from Keystore.
      */
-    void removeBiometricKeyEncryptor();
+    void removeBiometricKeyEncryptor(@NonNull String keyId);
 
     /**
      * @return {@link IBiometricKeyEncryptor} constructed with key stored in KeyStore or {@code null}
      *         if no such key is stored.
      */
     @Nullable
-    IBiometricKeyEncryptor getBiometricKeyEncryptor();
+    IBiometricKeyEncryptor getBiometricKeyEncryptor(@NonNull String keyId);
+
+    /**
+     * Return identifier of legacy key shared between multiple PowerAuthSDK instances.
+     * @return Identifier of shared legacy key.
+     */
+    @NonNull
+    String getLegacySharedKeyId();
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IBiometricKeystore.java
@@ -35,6 +35,7 @@ public interface IBiometricKeystore {
     /**
      * Check if a key for biometric key encryptor is present in Keystore and {@link IBiometricKeyEncryptor}
      * can be acquired.
+     * @param keyId Key identifier.
      *
      * @return {@code true} in case a key for biometric key encryptor is present, false otherwise.
      *         Method returns false in case Keystore is not properly initialized (call {@link #isKeystoreReady()}).
@@ -49,6 +50,7 @@ public interface IBiometricKeystore {
      *
      * @param invalidateByBiometricEnrollment Sets whether the new key should be invalidated on biometric enrollment.
      * @param useSymmetricKey Sets whether symmetric key should be created.
+     * @param keyId Key identifier.
      *
      * @return New generated {@link IBiometricKeyEncryptor} key or {@code null} in case of failure.
      */
@@ -57,10 +59,13 @@ public interface IBiometricKeystore {
 
     /**
      * Removes an encryption key from Keystore.
+     * @param keyId Key identifier.
      */
     void removeBiometricKeyEncryptor(@NonNull String keyId);
 
     /**
+     * Get implementation of {@link IBiometricKeyEncryptor} constructed with key stored in KeyStore.
+     * @param keyId Key identifier.
      * @return {@link IBiometricKeyEncryptor} constructed with key stored in KeyStore or {@code null}
      *         if no such key is stored.
      */

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/DefaultBiometricKeyEncryptorProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/DefaultBiometricKeyEncryptorProvider.java
@@ -54,12 +54,12 @@ public class DefaultBiometricKeyEncryptorProvider implements IBiometricKeyEncryp
     public IBiometricKeyEncryptor getBiometricKeyEncryptor() throws PowerAuthErrorException {
         if (encryptor == null) {
             if (request.isForceGenerateNewKey()) {
-                encryptor = keystore.createBiometricKeyEncryptor(request.isInvalidateByBiometricEnrollment(), request.isUseSymmetricCipher());
+                encryptor = keystore.createBiometricKeyEncryptor(request.getKeystoreAlias(), request.isInvalidateByBiometricEnrollment(), request.isUseSymmetricCipher());
                 if (encryptor == null) {
                     throw new PowerAuthErrorException(PowerAuthErrorCodes.BIOMETRY_NOT_SUPPORTED, "Keystore failed to generate a new biometric key.");
                 }
             } else {
-                encryptor = keystore.getBiometricKeyEncryptor();
+                encryptor = keystore.getBiometricKeyEncryptor(request.getKeystoreAlias());
                 if (encryptor == null) {
                     throw new PowerAuthErrorException(PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE, "Cannot get biometric key from the keystore.");
                 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/dummy/DummyBiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/dummy/DummyBiometricKeystore.java
@@ -16,6 +16,7 @@
 
 package io.getlime.security.powerauth.biometry.impl.dummy;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import io.getlime.security.powerauth.biometry.IBiometricKeyEncryptor;
@@ -33,23 +34,29 @@ public class DummyBiometricKeystore implements IBiometricKeystore {
     }
 
     @Override
-    public boolean containsBiometricKeyEncryptor() {
+    public boolean containsBiometricKeyEncryptor(@NonNull String keyId) {
         return false;
     }
 
     @Nullable
     @Override
-    public IBiometricKeyEncryptor createBiometricKeyEncryptor(boolean invalidateByBiometricEnrollment, boolean useSymmetricKey) {
+    public IBiometricKeyEncryptor createBiometricKeyEncryptor(@NonNull String keyId, boolean invalidateByBiometricEnrollment, boolean useSymmetricKey) {
         return null;
     }
 
     @Override
-    public void removeBiometricKeyEncryptor() {
+    public void removeBiometricKeyEncryptor(@NonNull String keyId) {
     }
 
     @Nullable
     @Override
-    public IBiometricKeyEncryptor getBiometricKeyEncryptor() {
+    public IBiometricKeyEncryptor getBiometricKeyEncryptor(@NonNull String keyId) {
         return null;
+    }
+
+    @NonNull
+    @Override
+    public String getLegacySharedKeyId() {
+        return "";
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.sdk;
 
 import androidx.annotation.NonNull;
 
+import androidx.annotation.Nullable;
 import io.getlime.security.powerauth.keychain.KeychainProtection;
 
 /**
@@ -28,19 +29,22 @@ public class PowerAuthKeychainConfiguration {
     public static final String KEYCHAIN_ID_STATUS = "io.getlime.PowerAuthKeychain.StatusKeychain";
     public static final String KEYCHAIN_ID_BIOMETRY = "io.getlime.PowerAuthKeychain.BiometryKeychain";
     public static final String KEYCHAIN_ID_TOKEN_STORE = "io.getlime.PowerAuthKeychain.TokenStoreKeychain";
-    public static final String KEYCHAIN_KEY_BIOMETRY_DEFAULT = "io.getlime.PowerAuthKeychain.BiometryKeychain.DefaultKey";
+    public static final String KEYCHAIN_KEY_BIOMETRY_DEFAULT = null;
+    public static final String KEYCHAIN_KEY_SHARED_BIOMETRY_KEY = "io.getlime.PowerAuthKeychain.BiometryKeychain.DefaultKey";
     public static final boolean DEFAULT_LINK_BIOMETRY_ITEMS_TO_CURRENT_SET = true;
     public static final boolean DEFAULT_CONFIRM_BIOMETRIC_AUTHENTICATION = false;
     public static final boolean DEFAULT_AUTHENTICATE_ON_BIOMETRIC_KEY_SETUP = true;
+    public static final boolean DEFAULT_ENABLE_FALLBACK_TO_SHARED_BIOMETRY_KEY = true;
     public static final @KeychainProtection int DEFAULT_REQUIRED_KEYCHAIN_PROTECTION = KeychainProtection.NONE;
 
     private final @NonNull String keychainIdStatus;
     private final @NonNull String keychainIdBiometry;
     private final @NonNull String keychainIdTokenStore;
-    private final @NonNull String keychainKeyBiometryDefault;
+    private final @Nullable String keychainKeyBiometry;
     private final boolean linkBiometricItemsToCurrentSet;
     private final boolean confirmBiometricAuthentication;
     private final boolean authenticateOnBiometricKeySetup;
+    private final boolean enableFallbackToSharedBiometryKey;
     private final @KeychainProtection int minimalRequiredKeychainProtection;
 
     /**
@@ -61,10 +65,21 @@ public class PowerAuthKeychainConfiguration {
 
     /**
      * Get name of the Keychain key used for storing the default biometry key information.
-     * @return Name of the biometry Keychain key.
+     * @return Name of the default biometry Keychain key.
+     * @deprecated Use {@link #getKeychainKeyBiometry()} method instead.
      */
+    @Deprecated // 1.7.10 - remove in 1.10.0
     public @NonNull String getKeychainBiometryDefaultKey() {
-        return keychainKeyBiometryDefault;
+       return keychainKeyBiometry == null ? KEYCHAIN_KEY_SHARED_BIOMETRY_KEY : keychainKeyBiometry;
+    }
+
+    /**
+     * Get name of the Keychain key used for storing the biometry key information for the PowerAuthSDK instance. If null
+     * then PowerAuthSDK instance will use its instance identifier to store the biometry key information.
+     * @return Get name of the Keychain key used for storing the biometry key information for the PowerAuthSDK instance.
+     */
+    public @Nullable String getKeychainKeyBiometry() {
+        return keychainKeyBiometry;
     }
 
     /**
@@ -111,6 +126,15 @@ public class PowerAuthKeychainConfiguration {
     }
 
     /**
+     * Get whether fallback to shared, legacy biometry key is enabled. By default, this is enabled for the compatibility
+     * reasons. If
+     * @return {@code true} if fallback to shared, legacy biometry key is enabled.
+     */
+    public boolean isFallbackToSharedBiometryKeyEnabled() {
+        return enableFallbackToSharedBiometryKey;
+    }
+
+    /**
      * Get minimal required keychain protection level that must be supported on the current device.
      * If the level of protection on the device is insufficient, then you cannot use PowerAuth
      * mobile SDK on the device. If not configured, then {@link KeychainProtection#NONE} is used
@@ -128,7 +152,7 @@ public class PowerAuthKeychainConfiguration {
      *
      * @param keychainIdStatus                  Name of the Keychain file used for storing the status information.
      * @param keychainIdBiometry                Name of the Keychain file used for storing the biometry key information.
-     * @param keychainKeyBiometryDefault        Name of the Keychain key used to store the default biometry key.
+     * @param keychainKeyBiometry               Name of the Keychain key used for storing the biometry key information for the PowerAuthSDK instance.
      * @param keychainIdTokenStore              Name of the Keychain file used for storing the access tokens.
      * @param linkBiometricItemsToCurrentSet    If set, then the item protected with the biometry is invalidated
      *                                          if fingers are added or removed, or if the user re-enrolls for face.
@@ -137,25 +161,29 @@ public class PowerAuthKeychainConfiguration {
      *                                          and may be ignored.
      * @param authenticateOnBiometricKeySetup   If set, then the biometric key setup always require biometric authentication.
      *                                          If not set, then only usage of biometric key require biometric authentication.
+     * @param enableFallbackToSharedBiometryKey If set, then the PowerAuthSDK does one more additional lookup to use legacy
+     *                                          key shared between multiple PowerAuthSDK instances.
      * @param minimalRequiredKeychainProtection {@link KeychainProtection} constant with minimal required keychain
      *                                          protection level that must be supported on the current device.
      */
     private PowerAuthKeychainConfiguration(
             @NonNull String keychainIdStatus,
             @NonNull String keychainIdBiometry,
-            @NonNull String keychainKeyBiometryDefault,
+            @Nullable String keychainKeyBiometry,
             @NonNull String keychainIdTokenStore,
             boolean linkBiometricItemsToCurrentSet,
             boolean confirmBiometricAuthentication,
             boolean authenticateOnBiometricKeySetup,
+            boolean enableFallbackToSharedBiometryKey,
             @KeychainProtection int minimalRequiredKeychainProtection) {
         this.keychainIdStatus = keychainIdStatus;
         this.keychainIdBiometry = keychainIdBiometry;
-        this.keychainKeyBiometryDefault = keychainKeyBiometryDefault;
+        this.keychainKeyBiometry = keychainKeyBiometry;
         this.keychainIdTokenStore = keychainIdTokenStore;
         this.linkBiometricItemsToCurrentSet = linkBiometricItemsToCurrentSet;
         this.confirmBiometricAuthentication = confirmBiometricAuthentication;
         this.authenticateOnBiometricKeySetup = authenticateOnBiometricKeySetup;
+        this.enableFallbackToSharedBiometryKey = enableFallbackToSharedBiometryKey;
         this.minimalRequiredKeychainProtection = minimalRequiredKeychainProtection;
     }
 
@@ -167,10 +195,11 @@ public class PowerAuthKeychainConfiguration {
         private @NonNull String keychainStatusId = KEYCHAIN_ID_STATUS;
         private @NonNull String keychainBiometryId = KEYCHAIN_ID_BIOMETRY;
         private @NonNull String keychainTokenStoreId = KEYCHAIN_ID_TOKEN_STORE;
-        private @NonNull String keychainBiometryDefaultKey = KEYCHAIN_KEY_BIOMETRY_DEFAULT;
+        private @Nullable String keychainKeyBiometry = KEYCHAIN_KEY_BIOMETRY_DEFAULT;
         private boolean linkBiometricItemsToCurrentSet = DEFAULT_LINK_BIOMETRY_ITEMS_TO_CURRENT_SET;
         private boolean confirmBiometricAuthentication = DEFAULT_CONFIRM_BIOMETRIC_AUTHENTICATION;
         private boolean authenticateOnBiometricKeySetup = DEFAULT_AUTHENTICATE_ON_BIOMETRIC_KEY_SETUP;
+        private boolean enableFallbackToSharedBiometryKey = DEFAULT_ENABLE_FALLBACK_TO_SHARED_BIOMETRY_KEY;
         private @KeychainProtection int minimalRequiredKeychainProtection = DEFAULT_REQUIRED_KEYCHAIN_PROTECTION;
 
         /**
@@ -215,11 +244,23 @@ public class PowerAuthKeychainConfiguration {
         /**
          * Set name of the Keychain key used to store the default biometry key.
          *
-         * @param keychainBiometryDefaultKey Name of the Keychain key used to store the default biometry key.
+         * @param keychainKeyBiometry Name of the Keychain key used to store the default biometry key.
+         * @return {@link Builder}
+         * @deprecated Use {@link #keychainKeyBiometry(String)} as a replacement.
+         */
+        @Deprecated // 1.7.10 - remove in 1.10.0
+        public @NonNull Builder keychainBiometryDefaultKey(@NonNull String keychainKeyBiometry) {
+            this.keychainKeyBiometry = keychainKeyBiometry;
+            return this;
+        }
+
+        /**
+         * Set the name of the key to the biometry Keychain to store biometry-factor protection key.
+         * @param keychainKeyBiometry name of the key to biometry keychain to store data containing biometry related encryption key.
          * @return {@link Builder}
          */
-        public @NonNull Builder keychainBiometryDefaultKey(@NonNull String keychainBiometryDefaultKey) {
-            this.keychainBiometryDefaultKey = keychainBiometryDefaultKey;
+        public @NonNull Builder keychainKeyBiometry(@NonNull String keychainKeyBiometry) {
+            this.keychainKeyBiometry = keychainKeyBiometry;
             return this;
         }
 
@@ -257,7 +298,7 @@ public class PowerAuthKeychainConfiguration {
          * <p>
          * If set to {@code false}, then RSA cipher is used and only the usage of biometric key
          * require the biometric authentication. This is due to fact, that RSA cipher can encrypt
-         * data with using it's public key available immediate after the key-pair is created in
+         * data with using its public key available immediate after the key-pair is created in
          * Android KeyStore.
          * <p>
          * The default value is {@code true}.
@@ -268,6 +309,20 @@ public class PowerAuthKeychainConfiguration {
          */
         public @NonNull Builder authenticateOnBiometricKeySetup(boolean authenticate) {
             this.authenticateOnBiometricKeySetup = authenticate;
+            return this;
+        }
+
+        /**
+         * (Optional) Set, whether PowerAuthSDK instance should also do additional lookup for a legacy biometric key,
+         * previously shared between multiple PowerAuthSDK object instances.
+         * <p>
+         * The default value is {@code true} and the fallback is enabled.
+         *
+         * @param enable If {@code true} then fallback to legacy key is enabled.
+         * @return {@link Builder}
+         */
+        public @NonNull Builder enableFallbackToSharedBiometryKey(boolean enable) {
+            this.enableFallbackToSharedBiometryKey = enable;
             return this;
         }
 
@@ -294,11 +349,12 @@ public class PowerAuthKeychainConfiguration {
             return new PowerAuthKeychainConfiguration(
                     keychainStatusId,
                     keychainBiometryId,
-                    keychainBiometryDefaultKey,
+                    keychainKeyBiometry,
                     keychainTokenStoreId,
                     linkBiometricItemsToCurrentSet,
                     confirmBiometricAuthentication,
                     authenticateOnBiometricKeySetup,
+                    enableFallbackToSharedBiometryKey,
                     minimalRequiredKeychainProtection);
         }
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1610,25 +1610,6 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      */
     public void removeActivationLocal(@NonNull Context context) {
-        removeActivationLocal(context, true);
-    }
-
-    /**
-     * Removes existing activation from the device.
-     * <p>
-     * This method removes the activation session state and optionally also shared biometry factor key. Cached possession related
-     * key remains intact. Unlike the `removeActivationWithAuthentication`, this method doesn't inform server about activation removal.
-     * In this case user has to remove the activation by using another channel (typically internet banking, or similar web management console)
-     * <p>
-     * <b>NOTE:</b>The removeSharedBiometryKey parameter is now ignored, because PowerAuthSDK no longer use the shared key for a newly created
-     * biometry factors.
-     *
-     * @param context                   Android context.
-     * @param removeSharedBiometryKey   This parameter is ignored.
-     * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
-     */
-    public void removeActivationLocal(@NonNull Context context, boolean removeSharedBiometryKey) {
-
         checkForValidSetup();
 
         final BiometricDataMapper.Mapping biometricDataMapping = mBiometricDataMapper.getMapping(null, context, BiometricDataMapper.BIO_MAPPING_REMOVE_KEY);
@@ -1649,6 +1630,26 @@ public class PowerAuthSDK {
         cancelGetActivationStatusTask();
         // Clear possible cached data
         clearCachedData();
+    }
+
+    /**
+     * Removes existing activation from the device.
+     * <p>
+     * This method removes the activation session state and optionally also shared biometry factor key. Cached possession related
+     * key remains intact. Unlike the `removeActivationWithAuthentication`, this method doesn't inform server about activation removal.
+     * In this case user has to remove the activation by using another channel (typically internet banking, or similar web management console)
+     * <p>
+     * <b>NOTE:</b>The removeSharedBiometryKey parameter is now ignored, because PowerAuthSDK no longer use the shared key for a newly created
+     * biometry factors.
+     *
+     * @param context                   Android context.
+     * @param removeSharedBiometryKey   This parameter is ignored.
+     * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
+     * @deprecated Use {@link #removeActivationLocal(Context)} as a replacement.
+     */
+    @Deprecated // 1.7.10 - remove in 1.10.0
+    public void removeActivationLocal(@NonNull Context context, boolean removeSharedBiometryKey) {
+        removeActivationLocal(context);
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/BiometricDataMapper.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/BiometricDataMapper.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk.impl;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.biometry.BiometricAuthentication;
+import io.getlime.security.powerauth.biometry.IBiometricKeystore;
+import io.getlime.security.powerauth.core.Session;
+import io.getlime.security.powerauth.keychain.Keychain;
+import io.getlime.security.powerauth.sdk.PowerAuthConfiguration;
+import io.getlime.security.powerauth.sdk.PowerAuthKeychainConfiguration;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * The {@code BiometricDataMapping} is a helper class that provides mapping for biometry-related encryption keys stored
+ * in the {@link Keychain} and the {@code Android KeyStore}. Previous versions of the SDK used a shared key for all
+ * {@code PowerAuthSDK} instances. This behavior was changed in the following SDK versions to use unique keys generated
+ * for each instance:
+ * <ul>
+ *     <li>{@code 1.7.10}</li>
+ *     <li>{@code 1.8.3}</li>
+ *     <li>{@code 1.9.0}</li>
+ * </ul>
+ * This class provides a compatibility layer that allows migration from the shared key to per-instance keys. If the
+ * application has already created an activation and is using the shared key, the provided mapping will point to the
+ * shared key until the biometric factor is removed by the application.
+ * <p>
+ * Related issue: <a href="https://github.com/wultra/powerauth-mobile-sdk/issues/620">Biometrics not working on multiple
+ * instances</a>.
+ */
+public class BiometricDataMapper {
+
+    /**
+     * The {@code Mapping} class contains information where the biometry-related encryption key is stored.
+     */
+    public static class Mapping {
+        /**
+         * If {@code true}, then this mapping points to the shared key.
+         */
+        public final boolean isSharedKey;
+        /**
+         * Key identifier (or alias) to the Android KeyStore.
+         */
+        public final @NonNull String keystoreId;
+        /**
+         * Storage key to the PowerAuth {@link Keychain}.
+         */
+        public final @NonNull String keychainKey;
+
+        /**
+         * Construct mapping with required parameters.
+         * @param isSharedKey Information whether the key is shared.
+         * @param keystoreId Key identifier (or alias) to the Android KeyStore.
+         * @param keychainKey Storage key to the PowerAuth {@link Keychain}.
+         */
+        Mapping(boolean isSharedKey, @NonNull String keystoreId, @NonNull String keychainKey) {
+            this.isSharedKey = isSharedKey;
+            this.keystoreId = keystoreId;
+            this.keychainKey = keychainKey;
+        }
+    }
+
+    /**
+     * No additional operation is required when the mapping is created.
+     */
+    public static final int BIO_MAPPING_NOOP = 0;
+    /**
+     * The mapping is required when the biometry-related encryption key is being newly crated. In this case, the mapper
+     * will always return a mapping to the per-instance data.
+     */
+    public static final int BIO_MAPPING_CREATE_KEY = 2;
+    /**
+     * The mapping is required when the biometry-related encryption key is being removed. If the current mapping contains
+     * the mapping to the shared, legacy key, then the mapper will return this legacy mapping. The next call to
+     * {@link #getMapping(IBiometricKeystore, Context, int)} will provide a mapping to the per-instance data.
+     */
+    public static final int BIO_MAPPING_REMOVE_KEY = 2;
+
+    private final ReentrantLock lock;
+    private final Session session;
+    private final String instanceId;
+    private final String keychainStorageKey;
+    private final boolean isFallbackToSharedBiometryKeyEnabled;
+    private final Keychain biometricKeychain;
+
+    /**
+     * The current mapping.
+     */
+    private Mapping mapping;
+
+    /**
+     * Create a helper object with all required parameters.
+     * @param sharedLock Instance of lock shared between multiple internal SDK objects.
+     * @param session Session instance.
+     * @param configuration PowerAuth SDK instance configuration.
+     * @param keychainConfiguration PowerAuth SDK keychain configuration.
+     * @param biometricKeychain A Keychain for storing biometry-related encryption keys.
+     */
+    public BiometricDataMapper(
+            @NonNull ReentrantLock sharedLock,
+            @NonNull Session session,
+            @NonNull PowerAuthConfiguration configuration,
+            @NonNull PowerAuthKeychainConfiguration keychainConfiguration,
+            @NonNull Keychain biometricKeychain) {
+        this.lock = sharedLock;
+        this.session = session;
+        this.instanceId = configuration.getInstanceId();
+        this.keychainStorageKey = keychainConfiguration.getKeychainKeyBiometry();
+        this.isFallbackToSharedBiometryKeyEnabled = keychainConfiguration.isFallbackToSharedBiometryKeyEnabled();
+        this.biometricKeychain = biometricKeychain;
+    }
+
+    /**
+     * Get the mapping for stored biometry-related encryption keys.
+     * @param keyStore Instance of {@link IBiometricKeystore} object. If not provided, then function gets default, shared keystore.
+     * @param context Android context object.
+     * @param purpose Specify situation in which the mapping is acquired. Use {@code BIO_MAPPING_*} constants from this class.
+     * @return Mapping for stored biometry-related encryption keys.
+     */
+    @NonNull
+    public Mapping getMapping(@Nullable IBiometricKeystore keyStore, @NonNull Context context, int purpose) {
+        try {
+            lock.lock();
+
+            if (keyStore == null) {
+                keyStore = BiometricAuthentication.getBiometricKeystore();
+            }
+
+            // New per-instance identifiers
+            final String instanceKeystoreId = instanceId;
+            final String instanceKeychainKey = keychainStorageKey != null ? keychainStorageKey : instanceId;
+
+            if (mapping == null) {
+                if ((purpose != BIO_MAPPING_CREATE_KEY) && isFallbackToSharedBiometryKeyEnabled) {
+                    // Legacy identifiers.
+                    final String legacyKeystoreId = keyStore.getLegacySharedKeyId();
+                    final String legacyKeychainKey = keychainStorageKey != null ? keychainStorageKey : PowerAuthKeychainConfiguration.KEYCHAIN_KEY_SHARED_BIOMETRY_KEY;
+                    if (session.hasBiometryFactor()) {
+                        // Looks like session has a biometry factor configured.
+                        // if per-instance keys are set, then don't use the shared encryptor and keychain data. We already have a new
+                        // setup applied on per-instance basis.
+                        if (!biometricKeychain.contains(instanceKeychainKey) && !keyStore.containsBiometricKeyEncryptor(instanceKeystoreId)) {
+                            if (biometricKeychain.contains(legacyKeychainKey) && keyStore.containsBiometricKeyEncryptor(legacyKeystoreId)) {
+                                // Looks like keychain and keystore contains data for a shared key, so try to use such key instead.
+                                mapping = new Mapping(true, legacyKeystoreId, legacyKeychainKey);
+                            }
+                        }
+                    }
+                }
+                if (mapping == null) {
+                    // Legacy config was not created, so create a new one, to use per-instance identifiers.
+                    mapping = new Mapping(false, instanceKeystoreId, instanceKeychainKey);
+                }
+            }
+            if (purpose == BIO_MAPPING_REMOVE_KEY) {
+                // We're going to remove key. If the current config is still legacy, then we should return this legacy
+                // mapping and simultaneously setup a new one.
+                if (mapping.isSharedKey) {
+                    final Mapping legacyMapping = mapping;
+                    mapping = new Mapping(false, instanceKeystoreId, instanceKeychainKey);
+                    return legacyMapping;
+                }
+            }
+            return mapping;
+        } finally {
+            lock.unlock();
+        }
+    }
+}


### PR DESCRIPTION
This PR modifies how the `PowerAuthSDK` class on Android internally stores biometry-related encryption keys. In previous versions, the key was shared between multiple `PowerAuthSDK` instances. Now, the shared key is only used if the activation has already configured a biometric factor. Once the factor using the shared key is removed, or the entire activation is removed, a per-instance key will be created during the next biometric setup.

This backward compatibility feature can be disabled in the `PowerAuthKeychainConfiguration` if required by the application. For instance, if the application uses multiple instances of `PowerAuthSDK`, it is important to disable this feature to ensure the shared key is immediately forgotten.

This PR is also back-ported to releases 1.7.x and 1.8.x (#626, #627)
