### PR TITLE
Support for OIDC activation

### DIFF
--- a/docs/Migration-from-1.8-to-1.9.md
+++ b/docs/Migration-from-1.8-to-1.9.md
@@ -6,6 +6,7 @@ PowerAuth Mobile SDK in version `1.9.0` provides the following improvements:
   - The PowerAuth protocol is no longer use EC key-pairs for encryption and signature calculation (dual use problem.)
   - The End-To-End encryption is now using a temporary keys to improve the forward secrecy of our ECIES scheme.
 - Simplified construction of encrypted request and response. Check updated [Android](PowerAuth-SDK-for-Android.md#end-to-end-encryption) or [iOS](PowerAuth-SDK-for-iOS.md#end-to-end-encryption) documentation for more details.
+- Now it's possible to create an activation via OpenID Connect provider.
 
 ### Compatibility with PowerAuth Server
 

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -7,6 +7,7 @@
 - [SDK Configuration](#configuration)
 - [Device Activation](#activation)
   - [Activation via Activation Code](#activation-via-activation-code)
+  - [Activation via OpenID Connect](#activation-via-openid-connect)
   - [Activation via Custom Credentials](#activation-via-custom-credentials)
   - [Activation via Recovery Code](#activation-via-recovery-code)
   - [Customize Activation](#customize-activation)
@@ -346,6 +347,45 @@ try {
 <!-- begin box warning -->
 Be aware that OTP can be used only if the activation is configured for ON_KEY_EXCHANGE validation on the PowerAuth server. See our [crypto documentation for details](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Additional-Activation-OTP.md#regular-activation-with-otp).
 <!-- end -->
+
+### Activation via OpenID Connect
+
+You may also create an activation using OIDC protocol:
+
+```kotlin
+// Create a new activation with a given device name and login credentials
+val deviceName = "Juraj's JiaYu S3"
+// Get the following information from your OpenID provider
+val providerId = "1234567890abcdef"
+val code = "1234567890abcdef"
+val nonce = "K1mP3rT9bQ8lV6zN7sW2xY4dJ5oU0fA1gH29o"
+val codeVerifier = "G3hsI1KZX1o~K0p-5lT3F7yZ4...6yP8rE2wO9n" // code verifier is optional
+
+// Create an activation object with the given credentials.
+val activation: PowerAuthActivation
+try {
+    activation = PowerAuthActivation.Builder.oidcActivation(providerId, code, nonce, codeVerifier)
+                    .setActivationName(deviceName)
+                    .build()
+} catch (e: PowerAuthErrorException) {
+    // Credentials dictionary is empty
+}
+
+// Create a new activation with the given activation object
+powerAuthSDK.createActivation(activation, object: ICreateActivationListener {
+    override fun onActivationCreateSucceed(result: CreateActivationResult) {
+        val fingerprint = result.activationFingerprint
+        val activationRecovery = result.recoveryData
+        // No error occurred, proceed to credentials entry (PIN prompt, Enable "Biometric Authentication" switch, ...) and persist
+        // The 'fingerprint' value represents the combination of device and server public keys - it may be used as visual confirmation
+        // If the server supports recovery codes for activation, then `activationRecovery` contains object with information about activation recovery.
+    }
+
+    override fun onActivationCreateFailed(t: Throwable) {
+        // Error occurred, report it to the user
+    }
+})
+```
 
 ### Activation via Custom Credentials
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -13,6 +13,7 @@
 - [SDK Configuration](#configuration)
 - [Device Activation](#activation)
   - [Activation via Activation Code](#activation-via-activation-code)
+  - [Activation via OpenID Connect](#activation-via-openid-connect)
   - [Activation via Custom Credentials](#activation-via-custom-credentials)
   - [Activation via Recovery Code](#activation-via-recovery-code)
   - [Customize Activation](#customize-activation)
@@ -232,6 +233,30 @@ guard let activation = try? PowerAuthActivation(activationCode: activationCode, 
 
 <!-- begin box warning -->
 Be aware that OTP can be used only if the activation is configured for ON_KEY_EXCHANGE validation on the PowerAuth server. See our [crypto documentation for details](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Additional-Activation-OTP.md#regular-activation-with-otp).
+<!-- end -->
+
+### Activation via OpenID Connect
+
+You may also create an activation using OIDC protocol:
+
+```swift
+// Create a new activation with a given device name and custom login credentials
+let deviceName = "Petr's iPhone 7"  // or UIDevice.current.name (see warning below)
+// Get the following information from your OpenID provider
+let providerId = "1234567890abcdef"
+let code = "1234567890abcdef"
+let nonce = "K1mP3rT9bQ8lV6zN7sW2xY4dJ5oU0fA1gH29o"
+let codeVerifier = "G3hsI1KZX1o~K0p-5lT3F7yZ4...6yP8rE2wO9n" // code verifier is optional
+
+// create an activation object with the given OIDC parameters
+guard let activation = try? PowerAuthActivation(oidcProviderId: providerId, code: code, nonce: nonce, codeVerifier: codeVerifier)
+    .with(activationName: deviceName) else {
+    // Activation parameter contains empty string
+}
+```
+
+<!-- begin box warning -->
+Note that if you use `UIDevice.current.name` for a device’s name, your application must include an [appropriate entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name); otherwise, the operating system will provide a generic `iPhone` string.
 <!-- end -->
 
 ### Activation via Custom Credentials

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthActivationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthActivationBuilderTest.java
@@ -86,7 +86,8 @@ public class PowerAuthActivationBuilderTest {
         additionalAttributes.put("test", "value");
         additionalAttributes.put("zero", 0);
 
-        PowerAuthActivation activation = PowerAuthActivation.Builder.activation("W65WE-3T7VI-7FBS2-A4OYA", "Named activation")
+        PowerAuthActivation activation = PowerAuthActivation.Builder.activation("W65WE-3T7VI-7FBS2-A4OYA")
+                .setActivationName("Named activation")
                 .setExtras("extras")
                 .setCustomAttributes(additionalAttributes)
                 .build();
@@ -123,15 +124,85 @@ public class PowerAuthActivationBuilderTest {
 
     @Test(expected = PowerAuthErrorException.class)
     public void createStandardActivationWithInvalidCode() throws Exception {
-        PowerAuthActivation.Builder.activation("W65WE-3T7VI-7FBS2-A4OYB", null)
+        PowerAuthActivation.Builder.activation("W65WE-3T7VI-7FBS2-A4OYB")
                 .build();
+    }
+
+    // OIDC
+
+    @Test
+    public void createOidcActivation() throws Exception {
+        final String providerId = "abc123";
+        final String code = "ABCDEFGH";
+        final String nonce = "K1mP3rT9bQ8lV6zN7sW2xY4dJ5oU0fA1gH29o";
+        final String codeVerifier = "G3hsI1KZX1o~K0p-5lT3F7yZ4bC8dE2jX9aQ6nO2rP3uS7wT5mV8jW1oY6xB3sD09tR4vU3qM1nG7kL6hV5wY2pJ0aF3eK9dQ8xN4mS2zB7oU5tL1cJ3vX6yP8rE2wO9n";
+        PowerAuthActivation activation = PowerAuthActivation.Builder.oidcActivation(providerId, code, nonce, null)
+                .build();
+
+        assertNotNull(activation);
+        assertEquals(ActivationType.DIRECT, activation.activationType);
+        assertNotNull(activation.identityAttributes);
+        assertEquals("oidc", activation.identityAttributes.get("method"));
+        assertEquals(providerId, activation.identityAttributes.get("providerId"));
+        assertEquals(code, activation.identityAttributes.get("code"));
+        assertEquals(nonce, activation.identityAttributes.get("nonce"));
+        assertNull(activation.identityAttributes.get("codeVerifier"));
+        assertNull(activation.activationName);
+
+        activation = PowerAuthActivation.Builder.oidcActivation(providerId, code, nonce, codeVerifier)
+                .build();
+
+        assertNotNull(activation);
+        assertEquals(ActivationType.DIRECT, activation.activationType);
+        assertNotNull(activation.identityAttributes);
+        assertEquals("oidc", activation.identityAttributes.get("method"));
+        assertEquals(providerId, activation.identityAttributes.get("providerId"));
+        assertEquals(code, activation.identityAttributes.get("code"));
+        assertEquals(nonce, activation.identityAttributes.get("nonce"));
+        assertEquals(codeVerifier, activation.identityAttributes.get("codeVerifier"));
+        assertNull(activation.activationName);
+    }
+
+    @Test
+    public void createOidcActivationWithName() throws Exception {
+        final String providerId = "abc123";
+        final String code = "ABCDEFGH";
+        final String nonce = "K1mP3rT9bQ8lV6zN7sW2xY4dJ5oU0fA1gH29o";
+        final String codeVerifier = "G3hsI1KZX1o~K0p-5lT3F7yZ4bC8dE2jX9aQ6nO2rP3uS7wT5mV8jW1oY6xB3sD09tR4vU3qM1nG7kL6hV5wY2pJ0aF3eK9dQ8xN4mS2zB7oU5tL1cJ3vX6yP8rE2wO9n";
+        PowerAuthActivation activation = PowerAuthActivation.Builder.oidcActivation(providerId, code, nonce, null)
+                .setActivationName("OIDC Activation")
+                .build();
+
+        assertNotNull(activation);
+        assertEquals(ActivationType.DIRECT, activation.activationType);
+        assertNotNull(activation.identityAttributes);
+        assertEquals("oidc", activation.identityAttributes.get("method"));
+        assertEquals(providerId, activation.identityAttributes.get("providerId"));
+        assertEquals(code, activation.identityAttributes.get("code"));
+        assertEquals(nonce, activation.identityAttributes.get("nonce"));
+        assertNull(activation.identityAttributes.get("codeVerifier"));
+        assertEquals("OIDC Activation", activation.activationName);
+
+        activation = PowerAuthActivation.Builder.oidcActivation(providerId, code, nonce, codeVerifier)
+                .setActivationName("OIDC Activation")
+                .build();
+
+        assertNotNull(activation);
+        assertEquals(ActivationType.DIRECT, activation.activationType);
+        assertNotNull(activation.identityAttributes);
+        assertEquals("oidc", activation.identityAttributes.get("method"));
+        assertEquals(providerId, activation.identityAttributes.get("providerId"));
+        assertEquals(code, activation.identityAttributes.get("code"));
+        assertEquals(nonce, activation.identityAttributes.get("nonce"));
+        assertEquals(codeVerifier, activation.identityAttributes.get("codeVerifier"));
+        assertEquals("OIDC Activation", activation.activationName);
     }
 
     // Recovery activations
 
     @Test
     public void createRecoveryActivation() throws Exception {
-        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890", null)
+        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890")
                 .build();
 
         assertNotNull(activation);
@@ -144,7 +215,7 @@ public class PowerAuthActivationBuilderTest {
 
     @Test
     public void createRecoveryActivationFromQrCode() throws Exception {
-        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("R:W65WE-3T7VI-7FBS2-A4OYA", "1234567890", null)
+        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("R:W65WE-3T7VI-7FBS2-A4OYA", "1234567890")
                 .build();
 
         assertNotNull(activation);
@@ -157,7 +228,8 @@ public class PowerAuthActivationBuilderTest {
 
     @Test
     public void createRecoveryActivationWithName() throws Exception {
-        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890", "Recovery")
+        PowerAuthActivation activation = PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890")
+                .setActivationName("Recovery")
                 .build();
 
         assertNotNull(activation);
@@ -193,20 +265,21 @@ public class PowerAuthActivationBuilderTest {
 
     @Test(expected = PowerAuthErrorException.class)
     public void createRecoveryActivationWithOtp() throws Exception {
-        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890", "Recovery")
+        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "1234567890")
+                .setActivationName("Recovery")
                 .setAdditionalActivationOtp("1234")
                 .build();
     }
 
     @Test(expected = PowerAuthErrorException.class)
     public void createRecoveryActivationWithInvalidCode() throws Exception {
-        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYB", "1234567890", null)
+        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYB", "1234567890")
                 .build();
     }
 
     @Test(expected = PowerAuthErrorException.class)
     public void createRecoveryActivationWithInvalidPuk() throws Exception {
-        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "123456789", null)
+        PowerAuthActivation.Builder.recoveryActivation("W65WE-3T7VI-7FBS2-A4OYA", "123456789")
                 .build();
     }
 
@@ -218,7 +291,7 @@ public class PowerAuthActivationBuilderTest {
         identityAttributes.put("login", "juraj");
         identityAttributes.put("password", "nbusr123");
 
-        PowerAuthActivation activation = PowerAuthActivation.Builder.customActivation(identityAttributes, null)
+        PowerAuthActivation activation = PowerAuthActivation.Builder.customActivation(identityAttributes)
                 .build();
 
         assertNotNull(activation);
@@ -236,7 +309,8 @@ public class PowerAuthActivationBuilderTest {
         identityAttributes.put("login", "juraj");
         identityAttributes.put("password", "nbusr123");
 
-        PowerAuthActivation activation = PowerAuthActivation.Builder.customActivation(identityAttributes, "CustomActivation")
+        PowerAuthActivation activation = PowerAuthActivation.Builder.customActivation(identityAttributes)
+                .setActivationName("CustomActivation")
                 .build();
 
         assertNotNull(activation);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/model/entity/ActivationType.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/model/entity/ActivationType.java
@@ -22,6 +22,7 @@ package io.getlime.security.powerauth.networking.model.entity;
  */
 public enum ActivationType {
     CODE,
+    DIRECT,
     CUSTOM,
     RECOVERY
 }

--- a/proj-xcode/PowerAuth2/PowerAuthActivation.h
+++ b/proj-xcode/PowerAuth2/PowerAuthActivation.h
@@ -30,6 +30,74 @@
 /**
  Create an instance of `PowerAuthActivation` configured with the activation code. The activation code may contain
  an optional signature part, in case that it is scanned from QR code.
+  
+ @param activationCode Activation code, obtained either via QR code scanning or by manual entry.
+ @param error Error reference in case some error occurs.
+ @return New instance of `PowerAuthActivation` or `nil` in case that activation code is invalid.
+ */
++ (nullable instancetype) activationWithActivationCode:(nonnull NSString*)activationCode
+                                                 error:(NSError * _Nullable * _Nullable)error;
+
+/**
+ Creates an instance of `PowerAuthActivation` with an identity attributes for the custom activation purposes.
+  
+ @param identityAttributes Custom activation parameters that are used to prove identity of a user.
+ @param error Error reference in case some error occurs.
+ @return New instance of `PowerAuthActivation` or `nil` in case that identity attributes are empty.
+ */
++ (nullable instancetype) activationWithIdentityAttributes:(nonnull NSDictionary<NSString*,NSString*>*)identityAttributes
+                                                     error:(NSError * _Nullable * _Nullable)error;
+
+/**
+ Creates an instance of `PowerAuthActivation` with a recovery activation code and PUK.
+ 
+ @param recoveryCode Recovery code, obtained either via QR code scanning or by manual entry.
+ @param recoveryPuk PUK obtained by manual entry.
+ @param error Error reference in case some error occurs.
+ @return New instance of `PowerAuthActivation` or `nil` in case that recovery code, or recovery PUK is invalid.
+ */
++ (nullable instancetype) activationWithRecoveryCode:(nonnull NSString*)recoveryCode
+                                         recoveryPuk:(nonnull NSString*)recoveryPuk
+                                               error:(NSError * _Nullable * _Nullable)error;
+
+/**
+ Creates an instance of `PowerAuthActivation` with OpenID connect credentials.
+ 
+ @param providerId OAuth 2.0 provider identification.
+ @param code OAuth 2.0 authorization code.
+ @param nonce Nonce used in the OAuth 2.0 flow.
+ @param codeVerifier Optional code verifier, in case that PKCE extension is used for an activation.
+ @param error Error reference in case some error occurs.
+ @return New instance of `PowerAuthActivation` or `nil` in case that some parameter contains empty string.
+ */
++ (nullable instancetype) activationWithOidcProviderId:(nonnull NSString*)providerId
+                                                  code:(nonnull NSString*)code
+                                                 nonce:(nonnull NSString*)nonce
+                                          codeVerifier:(nullable NSString*)codeVerifier
+                                                 error:(NSError * _Nullable * _Nullable)error;
+
+#pragma mark - Obsolete methods (will be deprecated in future version)
+
+/**
+ Creates an instance of `PowerAuthActivation` with a recovery activation code and PUK.
+ 
+ The activation's `name` parameter is optional, but recommended to set. You can use the value obtained from
+ `UIDevice.current.name` or let the user set the name. The name of activation will be associated with
+ an activation record on PowerAuth Server.
+ 
+ @param recoveryCode Recovery code, obtained either via QR code scanning or by manual entry.
+ @param recoveryPuk PUK obtained by manual entry.
+ @param name Activation name to be used for the activation.
+ @param error Error reference in case some error occurs.
+ @return New instance of `PowerAuthActivation` or `nil` in case that recovery code, or recovery PUK is invalid.
+ */
++ (nullable instancetype) activationWithRecoveryCode:(nonnull NSString*)recoveryCode
+                                         recoveryPuk:(nonnull NSString*)recoveryPuk
+                                                name:(nullable NSString*)name
+                                               error:(NSError * _Nullable * _Nullable)error;
+/**
+ Create an instance of `PowerAuthActivation` configured with the activation code. The activation code may contain
+ an optional signature part, in case that it is scanned from QR code.
  
  The activation's `name` parameter is optional, but recommended to set. You can use the value obtained from
  `UIDevice.current.name` or let the user set the name. The name of activation will be associated with
@@ -60,26 +128,19 @@
                                                       name:(nullable NSString*)name
                                                      error:(NSError * _Nullable * _Nullable)error;
 
+
+#pragma mark - Activation customization
+
 /**
- Creates an instance of `PowerAuthActivation` with a recovery activation code and PUK.
- 
- The activation's `name` parameter is optional, but recommended to set. You can use the value obtained from
+ Sets activation name. The activation's name parameter is optional, but recommended to set. You can use the value obtained from
  `UIDevice.current.name` or let the user set the name. The name of activation will be associated with
  an activation record on PowerAuth Server.
  
- @param recoveryCode Recovery code, obtained either via QR code scanning or by manual entry.
- @param recoveryPuk PUK obtained by manual entry.
- @param name Activation name to be used for the activation.
- @param error Error reference in case some error occurs.
- @return New instance of `PowerAuthActivation` or `nil` in case that recovery code, or recovery PUK is invalid.
+ @param activationName Name of activation.
+ @return The same object instance.
  */
-+ (nullable instancetype) activationWithRecoveryCode:(nonnull NSString*)recoveryCode
-                                         recoveryPuk:(nonnull NSString*)recoveryPuk
-                                                name:(nullable NSString*)name
-                                               error:(NSError * _Nullable * _Nullable)error;
-
-
-#pragma mark - Activation customization
+- (nonnull instancetype) withActivationName:(nonnull NSString*)activationName
+                         NS_SWIFT_NAME(with(activationName:));
 
 /**
  Sets extra attributes of the activation, used for application specific purposes (for example, info about the client

--- a/proj-xcode/PowerAuth2/PowerAuthActivation.m
+++ b/proj-xcode/PowerAuth2/PowerAuthActivation.m
@@ -61,6 +61,12 @@
 #pragma mark - Static initializers
 
 + (instancetype) activationWithActivationCode:(NSString*)activationCode
+                                        error:(NSError**)error
+{
+    return [self activationWithActivationCode:activationCode name:nil error:error];
+}
+
++ (instancetype) activationWithActivationCode:(NSString*)activationCode
                                          name:(NSString*)name
                                         error:(NSError**)error
 {
@@ -79,6 +85,12 @@
 }
 
 + (instancetype) activationWithIdentityAttributes:(NSDictionary<NSString*,NSString*>*)identityAttributes
+                                            error:(NSError**)error
+{
+    return [self activationWithIdentityAttributes:identityAttributes name:nil error:error];
+}
+
++ (instancetype) activationWithIdentityAttributes:(NSDictionary<NSString*,NSString*>*)identityAttributes
                                              name:(NSString*)name
                                             error:(NSError**)error
 {
@@ -92,6 +104,13 @@
                                                     activationType:@"CUSTOM"
                                                     activationCode:nil
                                                               name:name];
+}
+
++ (instancetype) activationWithRecoveryCode:(NSString*)recoveryCode
+                                recoveryPuk:(NSString*)recoveryPuk
+                                      error:(NSError**)error
+{
+    return [self activationWithRecoveryCode:recoveryCode recoveryPuk:recoveryPuk name:nil error:error];
 }
 
 + (instancetype) activationWithRecoveryCode:(NSString*)recoveryCode
@@ -119,8 +138,38 @@
                                                               name:name];
 }
 
++ (instancetype) activationWithOidcProviderId:(NSString *)providerId
+                                         code:(NSString *)code
+                                        nonce:(NSString *)nonce
+                                 codeVerifier:(NSString*)codeVerifier
+                                        error:(NSError **)error
+{
+    if (!providerId.length || !code.length || !nonce.length || (codeVerifier && !codeVerifier.length)) {
+        if (error) {
+            *error = PA2MakeError(PowerAuthErrorCode_InvalidActivationCode, @"Empty activation parameter");
+        }
+        return nil;
+    }
+    NSDictionary * identityAttributes;
+    if (codeVerifier) {
+        identityAttributes = @{ @"method": @"oidc", @"providerId": providerId, @"code": code, @"nonce": nonce, @"codeVerifier": codeVerifier };
+    } else {
+        identityAttributes = @{ @"method": @"oidc", @"providerId": providerId, @"code": code, @"nonce": nonce };
+    }
+    return [[PowerAuthActivation alloc] initWithIdentityAttributes:identityAttributes
+                                                    activationType:@"DIRECT"
+                                                    activationCode:nil
+                                                              name:nil];
+}
+
 
 #pragma mark - Customization
+
+- (instancetype) withActivationName:(NSString *)activationName
+{
+    _name = activationName;
+    return self;
+}
 
 - (instancetype) withExtras:(NSString *)extras
 {

--- a/proj-xcode/PowerAuth2Tests/PowerAuthActivationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthActivationTests.m
@@ -124,6 +124,39 @@ The `PowerAuthActivationTests` test class validates `PowerAuthActivation` object
     XCTAssertEqual(PowerAuthErrorCode_InvalidActivationData, error.code);
 }
 
+#pragma mark - OIDC
+
+- (void) testOidcActivation
+{
+    NSString * providerId = @"abc123";
+    NSString * code = @"ABCDEFGH";
+    NSString * nonce = @"K1mP3rT9bQ8lV6zN7sW2xY4dJ5oU0fA1gH29o";
+    NSString * codeVerifier = @"G3hsI1KZX1o~K0p-5lT3F7yZ4bC8dE2jX9aQ6nO2rP3uS7wT5mV8jW1oY6xB3sD09tR4vU3qM1nG7kL6hV5wY2pJ0aF3eK9dQ8xN4mS2zB7oU5tL1cJ3vX6yP8rE2wO9n";
+    id act1Identity = @{ @"method": @"oidc", @"providerId": providerId, @"code": code, @"nonce": nonce };
+    id act2Identity = @{ @"method": @"oidc", @"providerId": providerId, @"code": code, @"nonce": nonce, @"codeVerifier": codeVerifier };
+    NSError * error = nil;
+    PowerAuthActivation * act1 = [PowerAuthActivation activationWithOidcProviderId:providerId code:code nonce:nonce codeVerifier:nil error:&error];
+    XCTAssertNotNil(act1);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(@"DIRECT", act1.activationType);
+    XCTAssertEqualObjects(act1Identity, act1.identityAttributes);
+    XCTAssertNil(act1.activationCode);
+    XCTAssertNil(act1.name);
+    XCTAssertNil(act1.extras);
+    XCTAssertNil(act1.customAttributes);
+    XCTAssertTrue([act1 validate]);
+
+    PowerAuthActivation * act2 = [PowerAuthActivation activationWithOidcProviderId:providerId code:code nonce:nonce codeVerifier:codeVerifier error:&error];
+    XCTAssertNotNil(act2);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(@"DIRECT", act2.activationType);
+    XCTAssertEqualObjects(act2Identity, act2.identityAttributes);
+    XCTAssertNil(act2.activationCode);
+    XCTAssertNil(act2.name);
+    XCTAssertNil(act2.extras);
+    XCTAssertNil(act2.customAttributes);
+    XCTAssertTrue([act2 validate]);
+}
 
 #pragma mark - Custom
 
@@ -178,15 +211,16 @@ The `PowerAuthActivationTests` test class validates `PowerAuthActivation` object
     id expectedCustomAttrs = @{@"isPrimary":@(NO)};
     id expectedExtras = @"FL:123";
     NSError * error = nil;
-    PowerAuthActivation * act1 = [[[PowerAuthActivation activationWithActivationCode:@"VVVVV-VVVVV-VVVVV-VTFVA" name:nil error:&error]
-                                   withExtras:@"FL:123"]
+    PowerAuthActivation * act1 = [[[[PowerAuthActivation activationWithActivationCode:@"VVVVV-VVVVV-VVVVV-VTFVA" name:nil error:&error]
+                                    withActivationName:@"foo"]
+                                            withExtras:@"FL:123"]
                                   withCustomAttributes:@{@"isPrimary":@(NO)}];
     XCTAssertNotNil(act1);
     XCTAssertNil(error);
     XCTAssertEqualObjects(@"CODE", act1.activationType);
     XCTAssertEqualObjects(@{@"code":@"VVVVV-VVVVV-VVVVV-VTFVA"}, act1.identityAttributes);
     XCTAssertEqualObjects(@"VVVVV-VVVVV-VVVVV-VTFVA", act1.activationCode.activationCode);
-    XCTAssertNil(act1.name);
+    XCTAssertEqualObjects(@"foo", act1.name);
     XCTAssertEqualObjects(expectedExtras, act1.extras);
     XCTAssertEqualObjects(expectedCustomAttrs, act1.customAttributes);
     XCTAssertTrue([act1 validate]);


### PR DESCRIPTION
This PR adds support for new OIDC activation flow. Other changes:

- There's still "CUSTOM" activation type defined for custom activations.
-  All `PowerAuthActivation` object constructors are now available with no `activationName` parameter. The new recommended way to alter activation name is to use a new builder method `setActivationName()` or `with(activationName:)`. To avoid conflicts, I'll reflect this change in documentation in separate PR #618