### PR TITLE
Fixed uninitialized _fail_on_nosync_time in EciesClientEncryptor

### DIFF
--- a/src/PowerAuth/v3/EciesEncryptor.cpp
+++ b/src/PowerAuth/v3/EciesEncryptor.cpp
@@ -144,6 +144,7 @@ EciesClientEncryptor::EciesClientEncryptor(EncryptorParametersPtr& parameters,
     // In ECIES, each reques/response key is different, so we don't need to use
     // nonce generator to generate sequence of unique nonces.
     _request_nonce(GetRandomData(EciesEnvelopeKey::NonceSize)),
+    _fail_on_nosync_time(true),
     _time_sync_task(-1)
 {
 }


### PR DESCRIPTION
`EciesClientEncryptor::_fail_on_nosync_time` is never initialized by the  3-argument constructor, which is the one used by  `EciesEncryptorFactory::getClientEncryptor()` (`src/PowerAuth/v3/EciesEncryptorFactory.cpp:161`).

The 4-argument constructor does initialize it, but that overload is only used by  the unit tests (`src/PowerAuthTests/ClientEncryptorTests.cpp:235`) — so the  constructor that ships is the one that isn't covered.

 Reading the member in `encryptRequest()` is undefined behaviour, and the guard

```
if (!_time_service->isTimeSynchronized() && _fail_on_nosync_time) {
    throw Exception(EC_TimeNotSynchronized, ...);
}
```

may be skipped, allowing a request to be encrypted with an unsynchronized timestamp.

`v4::AeadClientEncryptor` initializes the flag correctly, so only protocol V3.3  is affected.