### PR TITLE
Fix #936: Automatic time synchronization no longer guaranteed when obtaining an E2EE encryptor

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,7 +1,14 @@
 # Changelog
 
 <!--------------------------------------------------->
-## 2.0.0 (TBA - Not released yet)
+## TBA - Not released yet
+
+### Both platforms
+
+- End-to-end request encryption no longer fails immediately when local time is not synchronized. The SDK now logs a warning and continues with request encryption ([936](https://github.com/wultra/powerauth-mobile-sdk/issues/936)).
+
+<!--------------------------------------------------->
+## 2.0.0 (August 2026)
 
 ### Important notice
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.integration.tests;
 import androidx.annotation.NonNull;
 
 import io.getlime.security.powerauth.core.CoreEncryptor;
+import io.getlime.security.powerauth.core.CoreEncryptedRequest;
 import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.keychain.Keychain;
 import io.getlime.security.powerauth.keychain.KeychainFactory;
@@ -672,6 +673,50 @@ public class BaseSdkTest extends BaseTest {
         });
         assertNotNull(actEncryptor);
         assertTrue(actEncryptor.canEncryptRequest());
+    }
+
+    @Test
+    public void testEncryptorEncryptsWithCachedKeyAfterTimeReset() throws Exception {
+        CoreEncryptor encryptor = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.getEncryptorForApplicationScope(new IGetEncryptorListener() {
+                @Override
+                public void onGetEncryptorSuccess(@NonNull CoreEncryptor encryptor) {
+                    resultCatcher.completeWithResult(encryptor);
+                }
+
+                @Override
+                public void onGetEncryptorFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithError(t);
+                }
+            });
+        });
+        assertNotNull(encryptor);
+        assertTrue(powerAuthSDK.getTimeSynchronizationService().isTimeSynchronized());
+
+        CoreEncryptedRequest encryptedRequest = encryptor.encryptRequest("{}".getBytes(StandardCharsets.UTF_8));
+        assertNotNull(encryptedRequest);
+
+        powerAuthSDK.getTimeSynchronizationService().resetTimeSynchronization();
+        assertFalse(powerAuthSDK.getTimeSynchronizationService().isTimeSynchronized());
+
+        encryptor = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.getEncryptorForApplicationScope(new IGetEncryptorListener() {
+                @Override
+                public void onGetEncryptorSuccess(@NonNull CoreEncryptor encryptor) {
+                    resultCatcher.completeWithResult(encryptor);
+                }
+
+                @Override
+                public void onGetEncryptorFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithError(t);
+                }
+            });
+        });
+        assertNotNull(encryptor);
+        assertFalse(powerAuthSDK.getTimeSynchronizationService().isTimeSynchronized());
+
+        encryptedRequest = encryptor.encryptRequest("{}".getBytes(StandardCharsets.UTF_8));
+        assertNotNull(encryptedRequest);
     }
 
     // TODO: This test is temporarily disabled, the used API doesn't work for protocol V4

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -2291,6 +2291,41 @@
     XCTAssertNotNil(encryptor);
 }
 
+- (void) testEncryptorEncryptsWithCachedKeyAfterTimeReset
+{
+    CHECK_TEST_CONFIG();
+
+    PowerAuthEncryptor * encryptor = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk encryptorForApplicationScopeWithCallback:^(PowerAuthEncryptor * _Nullable encryptor, NSError * _Nullable error) {
+            XCTAssertNil(error);
+            [waiting reportCompletion:encryptor];
+        }];
+    }];
+    XCTAssertNotNil(encryptor);
+    XCTAssertTrue(_sdk.timeSynchronizationService.isTimeSynchronized);
+    
+    NSError * error = nil;
+    PowerAuthEncryptedRequest * encryptedRequest = [encryptor encryptRequest:[@"{}" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+    XCTAssertNotNil(encryptedRequest);
+    XCTAssertNil(error);
+    
+    [_sdk.timeSynchronizationService resetTimeSynchronization];
+    XCTAssertFalse(_sdk.timeSynchronizationService.isTimeSynchronized);
+
+    encryptor = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk encryptorForApplicationScopeWithCallback:^(PowerAuthEncryptor * _Nullable encryptor, NSError * _Nullable error) {
+            XCTAssertNil(error);
+            [waiting reportCompletion:encryptor];
+        }];
+    }];
+    XCTAssertNotNil(encryptor);
+    XCTAssertFalse(_sdk.timeSynchronizationService.isTimeSynchronized);
+    
+    encryptedRequest = [encryptor encryptRequest:[@"{}" dataUsingEncoding:NSUTF8StringEncoding] error:&error];
+    XCTAssertNotNil(encryptedRequest);
+    XCTAssertNil(error);
+}
+
 #pragma mark - Vault keys
 
 - (PowerAuthSecureVaultKey*) fetchVaultEncryptionKey:(PowerAuthSecureVaultKeyId)keyId

--- a/src/PowerAuth/v3/EciesEncryptor.cpp
+++ b/src/PowerAuth/v3/EciesEncryptor.cpp
@@ -155,7 +155,6 @@ EciesClientEncryptor::EciesClientEncryptor(EncryptorParametersPtr& parameters,
     _parameters(std::move(parameters)),
     _secrets(std::move(secrets)),
     _time_service(time_service),
-    _fail_on_nosync_time(true),
     _request_nonce(nonce),
     _time_sync_task(-1)
 {
@@ -177,8 +176,8 @@ EncryptedRequest EciesClientEncryptor::encryptRequest(const ByteRange &data)
     if (!canEncryptRequest()) {
         throw Exception(EC_NotAllowed, "Cannot encrypt request");
     }
-    if (!_time_service->isTimeSynchronized() && _fail_on_nosync_time) {
-        throw Exception(EC_TimeNotSynchronized, "Encryption required time synchronized with server");
+    if (!_time_service->isTimeSynchronized()) {
+        CC7_LOG("WARNING: Time service is not synchronized. Encrypted data may be rejected on the server.");
     }
 
     auto timestamp = _time_service->currentTimeMillis();
@@ -236,15 +235,6 @@ ByteArray EciesClientEncryptor::decryptResponse(const EncryptedResponse &respons
     _time_sync_task = 0.0;
 
     return plaintext;
-}
-
-void EciesClientEncryptor::disableFailWhenTimeIsNotSynchronized()
-{
-#if DEBUG
-    _fail_on_nosync_time = false;
-#else
-    throw Exception(EC_InternalError, "Not implemented in RELEASE build");
-#endif
 }
 
 ByteArray EciesClientEncryptor::getAAD(Timestamp timestamp, const ByteRange & nonce, const ByteRange& ephemeral_key) const

--- a/src/PowerAuth/v3/EciesEncryptor.h
+++ b/src/PowerAuth/v3/EciesEncryptor.h
@@ -41,18 +41,12 @@ public:
     EncryptedRequest encryptRequest(const cc7::ByteRange &data) override;
     cc7::ByteArray decryptResponse(const EncryptedResponse &response) override;
 
-    /// Relax time synchronization validation for test purposes. The method does nothing
-    /// in release build of the library.
-    void disableFailWhenTimeIsNotSynchronized();
-
 private:
     const EncryptorParametersPtr _parameters;
     const EncryptorSecretsPtr _secrets;
     const TimeServicePtr _time_service;
     const cc7::ByteArray _request_nonce;
 
-    bool _fail_on_nosync_time;
-    
     TimeService::TaskId _time_sync_task;
     
     cc7::ByteArray getAAD(Timestamp timestamp, const cc7::ByteRange& nonce, const cc7::ByteRange& ephemeral_key) const;

--- a/src/PowerAuth/v4/AeadEncryptor.cpp
+++ b/src/PowerAuth/v4/AeadEncryptor.cpp
@@ -43,7 +43,6 @@ AeadClientEncryptor::AeadClientEncryptor(EncryptorParametersPtr& parameters,
     _secrets(std::move(secrets)),
     _nonce(nonce),
     _time_service(time_service),
-    _fail_on_nosync_time(true),
     _time_sync_task(-1)
 {
 #if DEBUG
@@ -75,8 +74,8 @@ EncryptedRequest AeadClientEncryptor::encryptRequest(const ByteRange &data)
     if (!canEncryptRequest()) {
         throw Exception(EC_NotAllowed, "Cannot encrypt request");
     }
-    if (!_time_service->isTimeSynchronized() && _fail_on_nosync_time) {
-        throw Exception(EC_TimeNotSynchronized, "Encryption required time synchronized with server");
+    if (!_time_service->isTimeSynchronized()) {
+        CC7_LOG("WARNING: Time is not synchronized. Encrypted data may be rejected on the server.");
     }
     
     const auto& aead = aeadAlg();
@@ -134,15 +133,6 @@ ByteArray AeadClientEncryptor::decryptResponse(const EncryptedResponse &response
     _time_sync_task = 0.0;
 
     return plaintext;
-}
-
-void AeadClientEncryptor::disableFailWhenTimeIsNotSynchronized()
-{
-#if DEBUG
-    _fail_on_nosync_time = false;
-#else
-    throw Exception(EC_InternalError, "Not implemented in RELEASE build");
-#endif
 }
 
 SymmetricKeyPtr AeadClientEncryptor::getKey() const

--- a/src/PowerAuth/v4/AeadEncryptor.h
+++ b/src/PowerAuth/v4/AeadEncryptor.h
@@ -37,17 +37,12 @@ public:
     EncryptedRequest encryptRequest(const cc7::ByteRange &data) override;
     cc7::ByteArray decryptResponse(const EncryptedResponse &response) override;
 
-    /// Relax time synchronization validation for test purposes. The method does nothing
-    /// in release build of the library.
-    void disableFailWhenTimeIsNotSynchronized();
-    
 private:
     const EncryptorParametersPtr _parameters;
     const EncryptorSecretsPtr _secrets;
     const cc7::ByteArray _nonce;
     const TimeServicePtr _time_service;
     
-    bool _fail_on_nosync_time;
     TimeService::TaskId _time_sync_task;
     
     cc7::ByteRange requestNonce() const;

--- a/src/PowerAuthTests/ClientEncryptorTests.cpp
+++ b/src/PowerAuthTests/ClientEncryptorTests.cpp
@@ -94,7 +94,6 @@ public:
             auto client_enc_secrets = v4::AEAD_BuildSecrets(*client_enc_params, envelope_key, e2ee_key);
             
             auto client_encryptor = v4::AeadClientEncryptor(client_enc_params, client_enc_secrets, nonce, timeService);
-            client_encryptor.disableFailWhenTimeIsNotSynchronized();
             ccstAssertTrue(client_encryptor.canEncryptRequest());
             ccstAssertFalse(client_encryptor.canDecryptResponse());
             
@@ -164,7 +163,6 @@ public:
             auto client_enc_secrets = v4::AEAD_BuildSecrets(*client_enc_params, envelopeKey, sharedInfo2Key);
             
             auto client_encryptor = v4::AeadClientEncryptor(client_enc_params, client_enc_secrets, nonce, timeService);
-            client_encryptor.disableFailWhenTimeIsNotSynchronized();
             
             // Enforce time in testing time provider
             timeProvider->setTimestamp(timestampRequest);
@@ -233,7 +231,6 @@ public:
             auto client_enc_secrets = v3::ECIES_TestClientSecrets(*client_enc_params, requestEphemeralPublicKey, envelopeKey, transportKey);
             
             auto client_encryptor = v3::EciesClientEncryptor(client_enc_params, client_enc_secrets, requestNonce, timeService);
-            client_encryptor.disableFailWhenTimeIsNotSynchronized();
             
             // Enforce time in testing time provider
             timeProvider->setTimestamp(timestampRequest);


### PR DESCRIPTION
Fixes https://github.com/wultra/powerauth-mobile-sdk/issues/936

End-to-end request encryption no longer fails immediately when local time is not synchronized. The SDK now logs a warning and continues with request encryption.